### PR TITLE
signature outside of content

### DIFF
--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -56,7 +56,7 @@
 	{posts.content}
 </div>
 <!-- IF posts.user.signature -->
-<div class="post-signature">{posts.user.signature}</div>
+<div component="post/signature" data-uid="{posts.user.uid}" class="post-signature">{posts.user.signature}</div>
 <!-- ENDIF posts.user.signature -->
 
 

--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -54,10 +54,10 @@
 <br />
 <div class="content" component="post/content" itemprop="text">
 	{posts.content}
-	<!-- IF posts.user.signature -->
-	<div class="post-signature">{posts.user.signature}</div>
-	<!-- ENDIF posts.user.signature -->
 </div>
+<!-- IF posts.user.signature -->
+<div class="post-signature">{posts.user.signature}</div>
+<!-- ENDIF posts.user.signature -->
 
 
 <small data-editor="{posts.editor.userslug}" component="post/editor" class="hidden">[[global:last_edited_by_ago, <strong>{posts.editor.username}</strong>, <span class="timeago" title="{posts.relativeEditTime}"></span>]]</small>


### PR DESCRIPTION
I noticed that the `post-signature` is nested into `content`, while fixing plugin-poll.
This is inconsistent with theme-lavender [templates/topic.tpl#L39-L42](https://github.com/NodeBB/nodebb-theme-lavender/blob/master/templates/topic.tpl#L39-L42).