### PR TITLE
Comment out .fix-lists

### DIFF
--- a/less/topic.less
+++ b/less/topic.less
@@ -239,7 +239,7 @@
 		}
 
 		.content {
-			.fix-lists;
+			/*.fix-lists;*/
 
 			blockquote {
 				font-size: 85%;


### PR DESCRIPTION
This is causing nodebb to fail to launch because this cannot be rectified by the less compiler. Commenting out until it's either fully removed or fully implemented.