### PR TITLE
Fix nested row markup on groups page

### DIFF
--- a/templates/groups/list.tpl
+++ b/templates/groups/list.tpl
@@ -5,17 +5,19 @@
 		<!-- ENDIF allowGroupCreation -->
 	</div>
 	<div class="col-lg-8">
-		<div class="col-xs-3 text-left pull-right">
-			<select class="form-control" id="search-sort">
-				<option value="alpha">[[groups:details.group_name]]</option>
-				<option value="count">[[groups:details.member_count]]</option>
-				<option value="date">[[groups:details.creation_date]]</option>
-			</select>
-		</div>
-		<div class="col-xs-5 text-left pull-right">
-			<div class="input-group">
-				<input type="text" class="form-control" placeholder="[[global:search]]" name="query" value="" id="search-text">
-				<span id="search-button" class="input-group-addon search-button"><i class="fa fa-search"></i></span>
+		<div class="row">
+			<div class="col-xs-3 text-left pull-right">
+				<select class="form-control" id="search-sort">
+					<option value="alpha">[[groups:details.group_name]]</option>
+					<option value="count">[[groups:details.member_count]]</option>
+					<option value="date">[[groups:details.creation_date]]</option>
+				</select>
+			</div>
+			<div class="col-xs-5 text-left pull-right">
+				<div class="input-group">
+					<input type="text" class="form-control" placeholder="[[global:search]]" name="query" value="" id="search-text">
+					<span id="search-button" class="input-group-addon search-button"><i class="fa fa-search"></i></span>
+				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This should make the group-name option list lose the whitespace to the right of it as seen [here](https://community.nodebb.org/groups).

There was just a `row` class missing.