### PR TITLE
Added alt text to navbar profile image

### DIFF
--- a/templates/partials/menu.tpl
+++ b/templates/partials/menu.tpl
@@ -27,7 +27,7 @@
 				<ul id="logged-in-menu" class="nav navbar-nav navbar-right">
 					<li id="user_label" class="dropdown">
 						<a class="dropdown-toggle" data-toggle="dropdown" href="#" id="user_dropdown" title="[[global:header.profile]]">
-							<img component="header/userpicture" src="{user.picture}"/> <span id="user-header-name" class="visible-xs-inline">{user.username}</span>
+							<img component="header/userpicture" src="{user.picture}" alt="{user.username}" /> <span id="user-header-name" class="visible-xs-inline">{user.username}</span>
 						</a>
 						<ul id="user-control-list" component="header/usercontrol" class="dropdown-menu" aria-labelledby="user_dropdown">
 							<li>


### PR DESCRIPTION
I thought just the user's username would be suitable as the alt text but you may want to change that to something like "Profile photo of...".

Fixes #137 