### PR TITLE
Break long worded topic headings

### DIFF
--- a/less/categories.less
+++ b/less/categories.less
@@ -33,6 +33,7 @@
 				margin: 0;
 				margin-left: 62px;
 				width: 85%;
+				word-break: break-all;
 
 				strong {
 					color: @gray-dark;

--- a/less/topic.less
+++ b/less/topic.less
@@ -2,6 +2,7 @@
 	h1 {
 		line-height: 24px;
 		margin-bottom: 30px;
+		word-break: break-all;
 		
 		.topic-title {
 			font-size: 28px;


### PR DESCRIPTION
This fix is for topic `h1` headings but it may need to be applied to elements elsewhere as well.

Fixes #148 