### PR TITLE
Break long worded topic headings

### DIFF
--- a/less/categories.less
+++ b/less/categories.less
@@ -35,6 +35,8 @@
 			}
 
 			h2 {
+				display: block;
+				word-wrap: break-word;
 				font-size: 18px;
 				line-height: 22px;
 				margin: 0;

--- a/less/topic.less
+++ b/less/topic.less
@@ -4,6 +4,8 @@
 		margin-bottom: 30px;
 
 		.topic-title {
+			display: block;
+			word-wrap: break-word;
 			font-size: 28px;
 			color:inherit;
 			line-height: 32px;


### PR DESCRIPTION
Here's a second attempt at fixing long-worded topic headings.

Fixes #148 