### PR TITLE
Fix skin overwriting account-fab styles

### DIFF
--- a/less/account.less
+++ b/less/account.less
@@ -239,7 +239,7 @@
 }
 
 
-.account-fab {
+.account-fab.btn-group {
 	position: absolute;
 	right: 15px;
 	bottom: -26px;


### PR DESCRIPTION
When using a bootswatch skin the selectors of the skin like `media="screen" .btn-group` overwrite those like `.account-fab` since they're more specific with the media selector.

You might want to check for similar occurrences of this bug (when you've got time for this :D).