### PR TITLE
Promote teaser to be components

### DIFF
--- a/templates/partials/categories/item.tpl
+++ b/templates/partials/categories/item.tpl
@@ -31,7 +31,7 @@
 		<span class="{../unread-class} human-readable-number" title="{../totalPostCount}">{../totalPostCount}</span><br />
 		<small>[[global:posts]]</small>
 	</div>
-	<div class="col-md-3 col-sm-3 teaser hidden-xs">
+	<div class="col-md-3 col-sm-3 teaser hidden-xs" component="teaser">
 		<!-- IMPORT partials/categories/lastpost.tpl -->
 	</div>
 	<!-- ENDIF !../link -->

--- a/templates/partials/topics_list.tpl
+++ b/templates/partials/topics_list.tpl
@@ -84,7 +84,7 @@
 			<small>[[global:views]]</small>
 		</div>
 
-		<div class="col-md-3 col-sm-3 teaser hidden-xs">
+		<div class="col-md-3 col-sm-3 teaser hidden-xs" component="teaser">
 			<div class="card" style="border-color: {topics.category.bgColor}">
 				<!-- IF topics.unreplied -->
 				<p>


### PR DESCRIPTION
Would save me (i.e. the user's browser) a lot of conditionals, since post structure is almost, yet not completetly the same for teasers and post listings. I also don't like selecting DOM objects by classes (.teaser would do the trick, too), that much. Ya know, people writing their own themes and stuff :wink:

I'm onto changing theme-vanilla, theme-lavender and theme-quickstart, as well. There aren't any other official themes that need to be updated, are there?