### PR TITLE
Fixes #183: short body menu animation, paginator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ sftp-config.json
 *.sublime-project
 *.sublime-workspace
 .idea
+.vscode

--- a/less/style.less
+++ b/less/style.less
@@ -2,6 +2,7 @@
 
 html {
 	overflow-y: scroll;
+	min-height: 100%;
 }
 
 body {
@@ -15,6 +16,12 @@ body {
 		padding-top: 70px;
 		padding-bottom: 50px;
 	}
+
+	min-height: 100%;
+}
+
+#panel.slideout-panel {
+	min-height: 100vh;
 }
 
 button, a {

--- a/lib/persona.js
+++ b/lib/persona.js
@@ -152,8 +152,6 @@ $(document).ready(function() {
 				'top': $(window).scrollTop() + 'px',
 				'position': 'absolute'
 			});
-
-			loadNotificationsAndChat();
 		}
 
 		function loadNotificationsAndChat() {
@@ -177,6 +175,15 @@ $(document).ready(function() {
 				'position': 'fixed'
 			});
 			$('.slideout-open').removeClass('slideout-open');
+			$('.topic .pagination-block').css({ bottom: 0 });
+		});
+
+		slideout.on('beforeopen', function() {
+			var paginator = $('.topic .pagination-block')[0];
+			if (paginator) {
+				paginator.style.bottom = 0; // to trigger reflow
+				paginator.style.bottom = (paginator.getBoundingClientRect().bottom - window.innerHeight).toString() + 'px';
+			}
 		});
 
 		$('#menu [data-section="navigation"] ul').html($('#main-nav').html() + ($('#search-menu').html() || '') + ($('#logged-out-menu').html() || ''));


### PR DESCRIPTION
- Exclude `.vscode` directory
- `html` and `body` get `min-height: 100%`
- `#panel.slideout-panel` gets `min-height: 100vh` (100% viewport height)
- Don't need to call `loadNotificationsAndChat()` twice
- On menu close, return pagination to normal position
- As menu opens, reposition paginator to bottom of screen