### PR TITLE
Fix mobile profile dropdown menu on dark bootswatch themes

### DIFF
--- a/less/modules/bottom-sheet.less
+++ b/less/modules/bottom-sheet.less
@@ -13,7 +13,6 @@
         	padding: 0 5px;
         	max-height: 60%;
         
-        	background: #fff;
         	box-shadow: 0 2px 6px rgba(0,0,0,0.35);
         	overflow: auto;
         	-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
Don't override the background color of the bottom-sheet dropdown menu. It is already white on light themes and this makes white-on-white text on dark themes.

Fixes apapadimoulis/what-bugs#155.