### PR TITLE
Don't add a divider on every Profile Menu link.

### DIFF
--- a/templates/partials/account/menu.tpl
+++ b/templates/partials/account/menu.tpl
@@ -66,7 +66,9 @@
 		<!-- ENDIF showHidden -->
 
 		<!-- BEGIN profile_links -->
+		<!-- IF @first -->
 		<li class="divider"></li>
+		<!-- ENDIF @first -->
 		<li id="{profile_links.id}" class="plugin-link <!-- IF profile_links.public -->public<!-- ELSE -->private<!-- ENDIF profile_links.public -->"><a href="{config.relative_path}/user/{userslug}/{profile_links.route}"><i class="fa fa-fw {profile_links.icon}"></i> {profile_links.name}</a></li>
 		<!-- END profile_links -->
 	</ul>


### PR DESCRIPTION
Looks silly.

![](http://puu.sh/sgSx4/f9eb7dc65a.png)