### PR TITLE
Move chats to a separate Slideout menu on the right side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ sftp-config.json
 *.sublime-workspace
 .idea
 .vscode
+node_modules

--- a/less/header.less
+++ b/less/header.less
@@ -1,4 +1,4 @@
-#menu, .header {
+.header, .slideout-menu {
 	.notification-list {
 		overflow-x: hidden;
 		overflow-y: auto;
@@ -313,10 +313,10 @@
 	font-family: @font-family-sans-serif;
 }
 
-#mobile-menu [component="notifications/icon"].unread-count:after, .slideout-menu .unread-count:after {
+.slideout-menu .unread-count:after {
 	position: relative;
-    	left: -6px;
-    	top: -7px;
+	left: -6px;
+	top: -7px;
 }
 
 #search-form {

--- a/less/mobile.less
+++ b/less/mobile.less
@@ -1,13 +1,7 @@
 
 .slideout-menu {
-	position: fixed;
-	top: 0;
-	bottom: 0;
-	z-index: 0;
-	width: 256px;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
-	display: none;
 }
 
 /* iPhone 5 and other such devices */
@@ -74,8 +68,10 @@
 		}
 	}
 
-	#chats-menu {
-		right: 0;
+	.slit-open {
+		&, body {
+			overflow: hidden;
+		}
 	}
 
 	#menu {

--- a/less/mobile.less
+++ b/less/mobile.less
@@ -72,6 +72,20 @@
 		&, body {
 			overflow: hidden;
 		}
+
+		#panel {
+			position: relative;
+
+			&::after {
+				position: absolute;
+				top: 0;
+				bottom: 0;
+				left: 0;
+				right: 0;
+				z-index: 1040;
+				content: ' ';
+			}
+		}
 	}
 
 	#menu {

--- a/less/mobile.less
+++ b/less/mobile.less
@@ -68,7 +68,7 @@
 		}
 	}
 
-	.slit-open {
+	html[data-slit=opening], html[data-slit=opened], html[data-slit=closing] {
 		&, body {
 			overflow: hidden;
 		}

--- a/less/mobile.less
+++ b/less/mobile.less
@@ -1,10 +1,8 @@
 
 .slideout-menu {
 	position: fixed;
-	left: auto;
 	top: 0;
 	bottom: 0;
-	right: 0;
 	z-index: 0;
 	width: 256px;
 	overflow-y: auto;
@@ -57,9 +55,34 @@
 		-webkit-overflow-scrolling: touch;
 	}
 
-	#menu {
+	.navbar-toggle {
+		line-height: 10px;
 
+		&.pull-left {
+			margin-left: @navbar-padding-horizontal;
+			margin-right: 0;
+		}
+
+		.header & .notification-icon {
+			left: auto;
+			top: -3px;
+			right: -8px;
+
+			&.unread-count::after {
+				position: static;
+			}
+		}
+	}
+
+	#chats-menu {
+		right: 0;
+	}
+
+	#menu {
 		padding-top: 100px;
+	}
+
+	.slideout-menu {
 		background-color: #1D1F20;
 		background-image: linear-gradient(145deg, #1D1F20, #404348);
 
@@ -81,15 +104,15 @@
 				color: #fff;
 				position: relative;
 				height: 60px;
-				
+
 				&:hover {
 					background: none;
 				}
-	
+
 				&:not(:last-child) {
 					border-bottom: none;
 				}
-				
+
 				.main-avatar {
 					position: absolute;
 					top: 0;
@@ -102,11 +125,11 @@
 						border-radius: 0;
 					}
 				}
-				
+
 				.members {
 					display: none;
 				}
-				
+
 				.room-name {
 					display: block;
 					overflow: hidden;
@@ -114,7 +137,7 @@
 					text-overflow: ellipsis;
 					padding-left: 60px;
 				}
-				
+
 				.teaser-content {
 					padding-left: 60px;
 					display: block;
@@ -127,24 +150,26 @@
 			}
 		}
 
-		.menu-section .chat-list, .menu-section .notification-list-mobile {
-			.user-link {
-				display: inline;
-			}
-			.unread {
-				background-color: inherit;
-
-				a:after {
-					content: "new";
-					text-transform: uppercase;
-					color: #FFF;
-					margin-left: 5px;
-					font-size: 10px;
-					background: #C91106;
-					border: 1px solid #890405;
-					padding: 2px 3px;
-					border-radius: 5px;
+		.menu-section {
+			.chat-list, .notification-list-mobile {
+				.user-link {
+					display: inline;
 				}
+				.unread {
+					background-color: inherit;
+				}
+			}
+			.chat-list .unread .room-name::after,
+			.notification-list-mobile .unread a::after {
+				content: "new";
+				text-transform: uppercase;
+				color: #FFF;
+				margin-left: 5px;
+				font-size: 10px;
+				background: #C91106;
+				border: 1px solid #890405;
+				padding: 2px 3px;
+				border-radius: 5px;
 			}
 		}
 
@@ -186,7 +211,7 @@
 	}
 
 	.menu-section-list {
-		padding:0;
+		padding: 0;
 		margin: 10px 0;
 		list-style:none;
 

--- a/lib/persona.js
+++ b/lib/persona.js
@@ -159,20 +159,7 @@ $(document).ready(function() {
 				if (chatsSlideout) { chatsSlideout.close(); }
 			}
 
-			function onBeforeOpen() {
-				requestAnimationFrame(fixPaginator);
-				$('#header-menu').css({
-					top: $(window).scrollTop() + 'px',
-					position: 'absolute',
-				});
-			}
-
 			function onClose() {
-				$('#header-menu').css({
-					top: 0,
-					position: 'fixed',
-				});
-				$('.topic .pagination-block').css({ bottom: 0 });
 				$('#panel').off('click', closeOnClick);
 			}
 
@@ -183,7 +170,6 @@ $(document).ready(function() {
 			});
 
 			slideout.ignore('code, code *, .preventSlideout, .preventSlideout *');
-			slideout.on('beforeopen', onBeforeOpen);
 			slideout.on('closed', onClose);
 			slideout.on('opened', function () {
 				$('#panel').one('click', closeOnClick);
@@ -191,7 +177,6 @@ $(document).ready(function() {
 
 			if (!guest) {
 				chatsSlideout.ignore('code, code *, .preventSlideout, .preventSlideout *');
-				chatsSlideout.on('beforeopen', onBeforeOpen);
 				chatsSlideout.on('closed', onClose);
 				chatsSlideout.on('opened', function () {
 					$('#panel').one('click', closeOnClick);
@@ -260,6 +245,10 @@ $(document).ready(function() {
 					slideout.enable();
 				});
 			}
+
+			// for debugging
+			// window.slideout = slideout;
+			// window.chatsSlideout = chatsSlideout;
 		});
 	}
 

--- a/lib/persona.js
+++ b/lib/persona.js
@@ -215,8 +215,6 @@ $(document).ready(function() {
 			if (!guest) {
 				slideout.on('beforeopen', function () {
 					chatsSlideout.close();
-				});
-				slideout.on('opened', function () {
 					chatsSlideout.disable();
 				});
 				slideout.on('closed', function () {
@@ -256,8 +254,6 @@ $(document).ready(function() {
 
 				chatsSlideout.on('beforeopen', function () {
 					slideout.close();
-				});
-				chatsSlideout.on('opened', function () {
 					slideout.disable();
 				});
 				chatsSlideout.on('closed', function () {

--- a/lib/persona.js
+++ b/lib/persona.js
@@ -152,6 +152,12 @@ $(document).ready(function() {
 				}
 			}
 
+			function closeOnClick(e) {
+				e.preventDefault();
+				slideout.close();
+				if (chatsSlideout) { chatsSlideout.close(); }
+			}
+
 			function onBeforeOpen() {
 				requestAnimationFrame(fixPaginator);
 				$('#header-menu').css({
@@ -166,6 +172,7 @@ $(document).ready(function() {
 					position: 'fixed',
 				});
 				$('.topic .pagination-block').css({ bottom: 0 });
+				$('#panel').off('click', closeOnClick);
 			}
 
 			$(window).on('resize action:ajaxify.start', function () {
@@ -177,11 +184,17 @@ $(document).ready(function() {
 			slideout.ignore('code, code *, .preventSlideout, .preventSlideout *');
 			slideout.on('beforeopen', onBeforeOpen);
 			slideout.on('closed', onClose);
+			slideout.on('opened', function () {
+				$('#panel').one('click', closeOnClick);
+			});
 
 			if (!guest) {
 				chatsSlideout.ignore('code, code *, .preventSlideout, .preventSlideout *');
 				chatsSlideout.on('beforeopen', onBeforeOpen);
 				chatsSlideout.on('closed', onClose);
+				chatsSlideout.on('opened', function () {
+					$('#panel').one('click', closeOnClick);
+				});
 			}
 
 			// left slideout navigation menu

--- a/lib/persona.js
+++ b/lib/persona.js
@@ -154,7 +154,7 @@ $(document).ready(function() {
 				}
 			}
 
-			function closeOnClick(e) {
+			function closeOnClick() {
 				slideout.close();
 				if (chatsSlideout) { chatsSlideout.close(); }
 			}

--- a/lib/persona.js
+++ b/lib/persona.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/*globals ajaxify, config, utils, app, socket, Slideout, NProgress*/
+/*globals ajaxify, config, utils, app, socket, NProgress*/
 
 $(document).ready(function() {
 	var env = utils.findBootstrapEnvironment();
@@ -117,87 +117,135 @@ $(document).ready(function() {
 			return;
 		}
 
-		$('#menu').removeClass('hidden');
+		var raf = requestAnimationFrame || function (cb) { setTimeout(cb, 1); };
 
-		var slideout = new Slideout({
-			'panel': document.getElementById('panel'),
-			'menu': document.getElementById('menu'),
-			'padding': 256,
-			'tolerance': 70,
-			'side': 'right'
-		});
+		require(['slideout'], function (Slideout) {
+			// initialization
 
-		if (env !== 'xs') {
-			slideout.disableTouch();
-		}
-
-		$('#mobile-menu').on('click', function() {
-			slideout.toggle();
-		});
-
-		$('#menu a').on('click', function() {
-			slideout.close();
-		});
-
-		$(window).on('resize action:ajaxify.start', function() {
-			slideout.close();
-			$('.account .cover').css('top', $('[component="navbar"]').height());
-		});
-
-		function openingMenuAndLoad() {
-			openingMenu();
-			loadNotificationsAndChat();
-		}
-
-		function openingMenu() {
-			$('#header-menu').css({
-				'top': $(window).scrollTop() + 'px',
-				'position': 'absolute'
+			var slideout = new Slideout({
+				panel: document.getElementById('panel'),
+				menu: document.getElementById('menu'),
+				padding: 256,
+				tolerance: 70,
+				touch: env === 'xs',
 			});
-		}
 
-		function loadNotificationsAndChat() {
-			require(['chat', 'notifications'], function(chat, notifications) {
-				chat.loadChatsDropdown($('#menu [data-section="chats"] ul'));
-				notifications.loadNotifications($('#menu [data-section="notifications"] ul'));
+			var chatsSlideout = new Slideout({
+				panel: document.getElementById('panel'),
+				menu: document.getElementById('chats-menu'),
+				padding: 256,
+				tolerance: 70,
+				side: 'right',
+				touch: false,
 			});
-		}
 
-		slideout.on('open', openingMenuAndLoad);
-		slideout.on('touchmove', function(target) {
-			var $target = $(target);
-			if ($target.length && ($target.is('code') || $target.parents('code').length || $target.hasClass('preventSlideOut') || $target.parents('.preventSlideOut').length)) {
-				slideout._preventOpen = true;
+			// all menus
+
+			$('#menu, #chats-menu').removeClass('hidden');
+
+			function fixPaginator() {
+				var paginator = $('.topic .pagination-block')[0];
+				if (paginator) {
+					paginator.style.bottom = 0; // to trigger reflow
+					paginator.style.bottom = (paginator.getBoundingClientRect().bottom - window.innerHeight).toString() + 'px';
+				}
 			}
-		});
 
-		slideout.on('close', function() {
-			$('#header-menu').css({
-				'top': '0px',
-				'position': 'fixed'
-			});
-			$('.slideout-open').removeClass('slideout-open');
-			$('.topic .pagination-block').css({ bottom: 0 });
-		});
-
-		slideout.on('beforeopen', function() {
-			var paginator = $('.topic .pagination-block')[0];
-			if (paginator) {
-				paginator.style.bottom = 0; // to trigger reflow
-				paginator.style.bottom = (paginator.getBoundingClientRect().bottom - window.innerHeight).toString() + 'px';
+			function onBeforeOpen() {
+				raf(fixPaginator);
+				$('#header-menu').css({
+					top: $(window).scrollTop() + 'px',
+					position: 'absolute',
+				});
 			}
-		});
 
-		$('#menu [data-section="navigation"] ul').html($('#main-nav').html() + ($('#search-menu').html() || '') + ($('#logged-out-menu').html() || ''));
+			function onTranslateStart(target) {
+				// don't open sometimes
+				var $target = $(target);
+				var open = this.isOpen();
+				if (
+					$('html').hasClass('slideout-open') && !open ||
+					$target.length && $target.is('code, code *, .preventSlideout, .preventSlideout *')
+				) {
+					this._preventOpen = true;
+				} else if (!open) {
+					onBeforeOpen();
+				}
+			}
 
-		$('#user-control-list').children().clone(true, true).appendTo($('#menu [data-section="profile"] ul'));
-		$('#menu [data-section="profile"] ul').find('[component="user/status"]').remove();
+			function onClose() {
+				$('#header-menu').css({
+					top: 0,
+					position: 'fixed',
+				});
+				$('.slideout-open').removeClass('slideout-open');
+				$('.topic .pagination-block').css({ bottom: 0 });
+			}
 
-		socket.on('event:user_status_change', function(data) {
-			if (parseInt(data.uid, 10) === app.user.uid) {
-				app.updateUserStatus($('#menu [component="user/status"]'), data.status);
+			$(window).on('resize action:ajaxify.start', function () {
 				slideout.close();
+				chatsSlideout.close();
+				$('.account .cover').css('top', $('[component="navbar"]').height());
+			});
+
+			slideout.on('beforeopen', onBeforeOpen);
+			chatsSlideout.on('beforeopen', onBeforeOpen);
+
+			slideout.on('translatestart', onTranslateStart);
+			// chatsSlideout.on('translatestart', onTranslateStart);
+
+			slideout.on('close', onClose);
+			chatsSlideout.on('close', onClose);
+
+			// left slideout navigation menu
+
+			$('#mobile-menu').on('click', function () {
+				slideout.toggle();
+			});
+
+			function loadNotifications() {
+				require(['notifications'], function(notifications) {
+					notifications.loadNotifications($('#menu [data-section="notifications"] ul'));
+				});
 			}
+
+			slideout.on('open', loadNotifications);
+
+			slideout.on('beforeopen', function () {
+				$('#chats-menu').hide();
+			});
+			slideout.on('translatestart', function () {
+				$('#chats-menu').hide();
+			});
+			slideout.on('close', function () {
+				$('#chats-menu').show();
+			});
+
+			$('#menu [data-section="navigation"] ul').html($('#main-nav').html() + ($('#search-menu').html() || '') + ($('#logged-out-menu').html() || ''));
+
+			$('#user-control-list').children().clone(true, true).appendTo($('#menu [data-section="profile"] ul'));
+			$('#menu [data-section="profile"] ul').find('[component="user/status"]').remove();
+
+			socket.on('event:user_status_change', function(data) {
+				if (parseInt(data.uid, 10) === app.user.uid) {
+					app.updateUserStatus($('#menu [component="user/status"]'), data.status);
+					slideout.close();
+				}
+			});
+
+			// right slideout chats menu
+
+			function loadChats() {
+				require(['chat'], function (chat) {
+					chat.loadChatsDropdown($('#chats-menu .chat-list'));
+				});
+			}
+
+			$('#mobile-chats').on('click', function() {
+				chatsSlideout.toggle();
+			});
+
+			chatsSlideout.on('open', loadChats);
 		});
 	}
 
@@ -300,15 +348,15 @@ $(document).ready(function() {
 				x = ev.pageX - drop.width() / 2 - $(this).offset().left,
 				y = ev.pageY - drop.height() / 2 - $(this).offset().top;
 
-			drop.css({top: y + 'px', left: x + 'px'}).addClass('animate');
+			drop.css({ top: y + 'px', left: x + 'px' }).addClass('animate');
 		});
 	}
-	
+
 	function setupQuickReply() {
 		$(window).on('action:ajaxify.end', function(ev, data) {
 			if (data.url && data.url.match('^topic/')) {
 				require(['persona/quickreply'], function(quickreply) {
-					quickreply.init();	
+					quickreply.init();
 				});
 			}
 		});

--- a/lib/persona.js
+++ b/lib/persona.js
@@ -117,26 +117,22 @@ $(document).ready(function() {
 			return;
 		}
 
-		var raf = requestAnimationFrame || function (cb) { setTimeout(cb, 1); };
-
-		require(['slideout'], function (Slideout) {
+		require(['slit'], function (Slit) {
 			// initialization
 
-			var slideout = new Slideout({
+			var slideout = Slit({
 				panel: document.getElementById('panel'),
 				menu: document.getElementById('menu'),
-				padding: 256,
-				tolerance: 70,
-				touch: env === 'xs',
+				width: 256,
+				margin: 50,
 			});
 
-			var chatsSlideout = new Slideout({
+			var chatsSlideout = Slit({
 				panel: document.getElementById('panel'),
 				menu: document.getElementById('chats-menu'),
-				padding: 256,
-				tolerance: 70,
+				width: 256,
+				margin: 50,
 				side: 'right',
-				touch: false,
 			});
 
 			// all menus
@@ -152,33 +148,21 @@ $(document).ready(function() {
 			}
 
 			function onBeforeOpen() {
-				raf(fixPaginator);
+				requestAnimationFrame(fixPaginator);
 				$('#header-menu').css({
 					top: $(window).scrollTop() + 'px',
 					position: 'absolute',
 				});
 			}
 
-			function onTranslateStart(target) {
-				// don't open sometimes
-				var $target = $(target);
-				var open = this.isOpen();
-				if (
-					$('html').hasClass('slideout-open') && !open ||
-					$target.length && $target.is('code, code *, .preventSlideout, .preventSlideout *')
-				) {
-					this._preventOpen = true;
-				} else if (!open) {
-					onBeforeOpen();
-				}
-			}
+			slideout.ignore('code, code *, .preventSlideout, .preventSlideout *');
+			chatsSlideout.ignore('code, code *, .preventSlideout, .preventSlideout *');
 
 			function onClose() {
 				$('#header-menu').css({
 					top: 0,
 					position: 'fixed',
 				});
-				$('.slideout-open').removeClass('slideout-open');
 				$('.topic .pagination-block').css({ bottom: 0 });
 			}
 
@@ -191,11 +175,8 @@ $(document).ready(function() {
 			slideout.on('beforeopen', onBeforeOpen);
 			chatsSlideout.on('beforeopen', onBeforeOpen);
 
-			slideout.on('translatestart', onTranslateStart);
-			// chatsSlideout.on('translatestart', onTranslateStart);
-
-			slideout.on('close', onClose);
-			chatsSlideout.on('close', onClose);
+			slideout.on('closed', onClose);
+			chatsSlideout.on('closed', onClose);
 
 			// left slideout navigation menu
 
@@ -209,16 +190,16 @@ $(document).ready(function() {
 				});
 			}
 
-			slideout.on('open', loadNotifications);
+			slideout.on('opened', loadNotifications);
 
 			slideout.on('beforeopen', function () {
-				$('#chats-menu').hide();
+				chatsSlideout.close();
 			});
-			slideout.on('translatestart', function () {
-				$('#chats-menu').hide();
+			slideout.on('opened', function () {
+				chatsSlideout.disable();
 			});
-			slideout.on('close', function () {
-				$('#chats-menu').show();
+			slideout.on('closed', function () {
+				chatsSlideout.enable();
 			});
 
 			$('#menu [data-section="navigation"] ul').html($('#main-nav').html() + ($('#search-menu').html() || '') + ($('#logged-out-menu').html() || ''));
@@ -244,8 +225,21 @@ $(document).ready(function() {
 			$('#mobile-chats').on('click', function() {
 				chatsSlideout.toggle();
 			});
+			$('#chats-menu').on('click', 'li[data-roomid]', function () {
+				chatsSlideout.close();
+			});
 
-			chatsSlideout.on('open', loadChats);
+			chatsSlideout.on('opened', loadChats);
+
+			chatsSlideout.on('beforeopen', function () {
+				slideout.close();
+			});
+			chatsSlideout.on('opened', function () {
+				slideout.disable();
+			});
+			chatsSlideout.on('closed', function () {
+				slideout.enable();
+			});
 		});
 	}
 

--- a/lib/persona.js
+++ b/lib/persona.js
@@ -117,6 +117,8 @@ $(document).ready(function() {
 			return;
 		}
 
+		var guest = !app.user || !parseInt(app.user.uid, 10);
+
 		require(['slit'], function (Slit) {
 			// initialization
 
@@ -126,18 +128,21 @@ $(document).ready(function() {
 				width: 256,
 				margin: 50,
 			});
+			$('#menu').removeClass('hidden');
 
-			var chatsSlideout = Slit({
-				panel: document.getElementById('panel'),
-				menu: document.getElementById('chats-menu'),
-				width: 256,
-				margin: 50,
-				side: 'right',
-			});
+			var chatsSlideout;
+			if (!guest) {
+				chatsSlideout = Slit({
+					panel: document.getElementById('panel'),
+					menu: document.getElementById('chats-menu'),
+					width: 256,
+					margin: 50,
+					side: 'right',
+				});
+				$('#chats-menu').removeClass('hidden');
+			}
 
 			// all menus
-
-			$('#menu, #chats-menu').removeClass('hidden');
 
 			function fixPaginator() {
 				var paginator = $('.topic .pagination-block')[0];
@@ -155,9 +160,6 @@ $(document).ready(function() {
 				});
 			}
 
-			slideout.ignore('code, code *, .preventSlideout, .preventSlideout *');
-			chatsSlideout.ignore('code, code *, .preventSlideout, .preventSlideout *');
-
 			function onClose() {
 				$('#header-menu').css({
 					top: 0,
@@ -172,11 +174,15 @@ $(document).ready(function() {
 				$('.account .cover').css('top', $('[component="navbar"]').height());
 			});
 
+			slideout.ignore('code, code *, .preventSlideout, .preventSlideout *');
 			slideout.on('beforeopen', onBeforeOpen);
-			chatsSlideout.on('beforeopen', onBeforeOpen);
-
 			slideout.on('closed', onClose);
-			chatsSlideout.on('closed', onClose);
+
+			if (!guest) {
+				chatsSlideout.ignore('code, code *, .preventSlideout, .preventSlideout *');
+				chatsSlideout.on('beforeopen', onBeforeOpen);
+				chatsSlideout.on('closed', onClose);
+			}
 
 			// left slideout navigation menu
 
@@ -192,15 +198,17 @@ $(document).ready(function() {
 
 			slideout.on('opened', loadNotifications);
 
-			slideout.on('beforeopen', function () {
-				chatsSlideout.close();
-			});
-			slideout.on('opened', function () {
-				chatsSlideout.disable();
-			});
-			slideout.on('closed', function () {
-				chatsSlideout.enable();
-			});
+			if (!guest) {
+				slideout.on('beforeopen', function () {
+					chatsSlideout.close();
+				});
+				slideout.on('opened', function () {
+					chatsSlideout.disable();
+				});
+				slideout.on('closed', function () {
+					chatsSlideout.enable();
+				});
+			}
 
 			$('#menu [data-section="navigation"] ul').html($('#main-nav').html() + ($('#search-menu').html() || '') + ($('#logged-out-menu').html() || ''));
 
@@ -222,24 +230,26 @@ $(document).ready(function() {
 				});
 			}
 
-			$('#mobile-chats').on('click', function() {
-				chatsSlideout.toggle();
-			});
-			$('#chats-menu').on('click', 'li[data-roomid]', function () {
-				chatsSlideout.close();
-			});
+			if (!guest) {
+				$('#mobile-chats').removeClass('hidden').on('click', function() {
+					chatsSlideout.toggle();
+				});
+				$('#chats-menu').on('click', 'li[data-roomid]', function () {
+					chatsSlideout.close();
+				});
 
-			chatsSlideout.on('opened', loadChats);
+				chatsSlideout.on('opened', loadChats);
 
-			chatsSlideout.on('beforeopen', function () {
-				slideout.close();
-			});
-			chatsSlideout.on('opened', function () {
-				slideout.disable();
-			});
-			chatsSlideout.on('closed', function () {
-				slideout.enable();
-			});
+				chatsSlideout.on('beforeopen', function () {
+					slideout.close();
+				});
+				chatsSlideout.on('opened', function () {
+					slideout.disable();
+				});
+				chatsSlideout.on('closed', function () {
+					slideout.enable();
+				});
+			}
 		});
 	}
 

--- a/lib/persona.js
+++ b/lib/persona.js
@@ -122,11 +122,13 @@ $(document).ready(function() {
 		require(['slit'], function (Slit) {
 			// initialization
 
+			var margin = window.innerWidth * 0.4;
+
 			var slideout = Slit({
 				panel: document.getElementById('panel'),
 				menu: document.getElementById('menu'),
 				width: 256,
-				margin: 50,
+				margin: margin,
 			});
 			$('#menu').removeClass('hidden');
 
@@ -136,7 +138,7 @@ $(document).ready(function() {
 					panel: document.getElementById('panel'),
 					menu: document.getElementById('chats-menu'),
 					width: 256,
-					margin: 50,
+					margin: margin,
 					side: 'right',
 				});
 				$('#chats-menu').removeClass('hidden');

--- a/lib/persona.js
+++ b/lib/persona.js
@@ -155,7 +155,6 @@ $(document).ready(function() {
 			}
 
 			function closeOnClick(e) {
-				e.preventDefault();
 				slideout.close();
 				if (chatsSlideout) { chatsSlideout.close(); }
 			}

--- a/lib/slit.js
+++ b/lib/slit.js
@@ -351,8 +351,11 @@
             return;
           }
 
+          var touch = e.touches[0];
+          var diff = (self.side === 'left' ? -1 : 1) * (touch.clientX - startX);
+
           if (firstMove) {
-            if (self.closed) {
+            if (self.closed && diff < 0) {
               self._trigger('beforeopen');
             } else if (self.opened) {
               self._trigger('beforeclose');
@@ -361,8 +364,6 @@
             panel.style.transition = 'none';
           }
 
-          var touch = e.touches[0];
-          var diff = (self.side === 'left' ? -1 : 1) * (touch.clientX - startX);
           var offset = Math.min(Math.max(0, startOffset + diff), self.width);
 
           if (firstMove) {

--- a/lib/slit.js
+++ b/lib/slit.js
@@ -141,7 +141,7 @@
         self.menu.style[self.side] = null;
         self.panel.style.transform = null;
 
-        if (self.opened || self.opening) {
+        if (!self.closed) {
           clearTimeout(self._timer);
 
           self.menu.classList.remove('open');
@@ -174,7 +174,7 @@
         self.menu.style[self.side] = null;
         self.panel.style.transform = null;
 
-        if (self.closed || self.closing) {
+        if (!self.opened) {
           clearTimeout(self._timer);
 
           self.menu.classList.add('open');
@@ -245,8 +245,6 @@
           return this.width - offset;
         }
       },
-      _startOffset: 0,
-      _startX: 0,
 
       _id: uuid(),
       _init: function () {
@@ -286,6 +284,11 @@
 
         // setup events
 
+        var startX = 0;
+        var startOffset = 0;
+        var lastOffset = self.width;
+        var firstMove = false;
+
         /** @param {TouchEvent} e */
         function onTouchstart(e) {
           var ignores = self._ignores.join(', ');
@@ -296,11 +299,6 @@
           if (self._disabled) {
             return;
           }
-          if (self.closed) {
-            self._trigger('beforeopen');
-          } else if (self.opened) {
-            self._trigger('beforeclose');
-          }
 
           self._touched = false;
           if (e.touches.length === 1) {
@@ -310,15 +308,13 @@
             if (self.side === 'left' && touch.clientX <= margin ||
                 self.side === 'right' && window.innerWidth - touch.clientX <= margin) {
               self._touched = true;
-              self._startX = touch.clientX;
-              self._startOffset = offset;
-              menu.style.transition = 'none';
-              panel.style.transition = 'none';
+              startX = touch.clientX;
+              startOffset = offset;
+              lastOffset = offset;
+              firstMove = true;
             }
           }
         }
-
-        var lastOffset = self.width;
 
         /** @param {TouchEvent} e */
         function onTouchmove(e) {
@@ -327,9 +323,32 @@
             return;
           }
 
+          if (firstMove) {
+            firstMove = false;
+
+            if (self.closed) {
+              self._trigger('beforeopen');
+            } else if (self.opened) {
+              self._trigger('beforeclose');
+            }
+            menu.style.transition = 'none';
+            panel.style.transition = 'none';
+          }
+
           var touch = e.touches[0];
-          var diff = (self.side === 'left' ? -1 : 1) * (touch.clientX - self._startX);
-          var offset = Math.min(Math.max(0, self._startOffset + diff), self.width);
+          var diff = (self.side === 'left' ? -1 : 1) * (touch.clientX - startX);
+          var offset = Math.min(Math.max(0, startOffset + diff), self.width);
+
+          self.opened = false;
+          self.closed = false;
+          if (offset > lastOffset) {
+            self.opening = false;
+            self.closing = true;
+          } else {
+            self.opening = true;
+            self.closing = false;
+          }
+
           if (self.type === 'drawer') {
             menu.style[self.side] = -offset + 'px';
           } else {
@@ -351,6 +370,7 @@
           } else {
             self.open();
           }
+
           self._touched = false;
           menu.style.transition = null;
           panel.style.transition = null;

--- a/lib/slit.js
+++ b/lib/slit.js
@@ -1,0 +1,366 @@
+(function (factory) {
+  'use strict';
+  if (typeof define === 'function' && define.amd) {
+    define(factory);
+  } else {
+    window.Slit = factory();
+  }
+})(function () {
+  'use strict';
+  function assert(condition) {
+    if (!condition) {
+      throw Error('AssertionError: Invalid arguments');
+    }
+  }
+
+  function uuid() {
+    var result = [];
+    for (var i = 0; i < 3; i++) {
+      result.push(Math.floor(Math.random() * 10000000).toString(32));
+    }
+    return result.join('-');
+  }
+
+  Element.prototype.matches =
+    Element.prototype.matchesSelector ||
+    Element.prototype.mozMatchesSelector ||
+    Element.prototype.msMatchesSelector ||
+    Element.prototype.oMatchesSelector ||
+    Element.prototype.webkitMatchesSelector;
+
+  /**
+   * @exports Slit
+   * Create a Slit instance
+   * @param {{ menu: Element, panel: Element, side: string, margin: number }} options
+   */
+  function Slit(options) {
+    assert(options.menu instanceof Element);
+    assert(options.panel instanceof Element);
+    assert(!options.side || options.side === 'left' || options.side === 'right');
+    assert(!options.type || options.type === 'drawer' || options.type === 'reveal');
+    assert(!options.margin || isFinite(options.margin));
+    assert(!options.timing || isFinite(options.timing));
+    assert(!options.width || isFinite(options.width));
+
+    var html = document.documentElement;
+
+    var slit = {
+      /**
+       * @type {Element}
+       * the element which contains your menu
+       */
+      menu: options.menu,
+      /**
+       * @type {Element}
+       * the element containing your site's main content
+       */
+      panel: options.panel,
+      /**
+       * @type {string}
+       * the side of the screen it should show on
+       */
+      side: options.side || 'left',
+      /**
+       * @type {string}
+       * whether the menu should open over the panel ('drawer')
+       * or the panel should be moved to reveal the menu ('reveal')
+       */
+      type: options.type || 'drawer',
+      /**
+       * @type {number}
+       * the number of pixels in which a touch event will be accepted
+       */
+      margin: options.margin || 10,
+      /**
+       * @type {number}
+       * milliseconds of the transition animation for opening and closing
+       */
+      timing: options.timing || 200,
+      /**
+       * @type {number}
+       * width of menu in pixels
+       */
+      width: options.width || 256,
+
+      /**
+       * @type {{ [key: string]: Function[] }}
+       */
+      _handlers: {
+        beforeclose: [],
+        closed: [],
+        beforeopen: [],
+        opened: [],
+        touchstart: [],
+        touchmove: [],
+        touchend: [],
+      },
+      /**
+       * Trigger event emitters for the event
+       * @private
+       * @param {string} eventName
+       * @param {Event} e
+       */
+      _trigger: function (eventName, e) {
+        var self = this;
+        self._handlers[eventName].forEach(function (handler) {
+          handler.call(self, e);
+        });
+      },
+      /**
+       * Add an event handler
+       * @param {string} eventName
+       * @param {Function} handler
+       */
+      on: function (eventName, handler) {
+        this._handlers[eventName].push(handler);
+      },
+      /**
+       * Remove all event handlers for an event
+       * @param {string} eventName
+       */
+      off: function (eventName) {
+        this._handlers[eventName] = [];
+      },
+
+      opened: false,
+      opening: false,
+      closed: true,
+      closing: false,
+
+      /**
+       * Close this menu
+       */
+      close: function () {
+        var self = this;
+
+        self._trigger('beforeclose');
+        if (self._disabled) {
+          return;
+        }
+
+        self.menu.style[self.side] = null;
+        self.panel.style.transform = null;
+
+        if (self.opened || self.opening) {
+          clearTimeout(self._timer);
+
+          self.menu.classList.remove('open');
+          self.opened = false;
+          self.opening = false;
+          self.closed = false;
+          self.closing = true;
+
+          self._timer = setTimeout(function () {
+            self.closing = false;
+            self.closed = true;
+
+            html.classList.remove('slit-open');
+            html.classList.remove('slit-open-' + self._id);
+            self._trigger('closed');
+          }, self.timing);
+        }
+      },
+      /**
+       * Open this menu
+       */
+      open: function () {
+        var self = this;
+
+        self._trigger('beforeopen');
+        if (self._disabled) {
+          return;
+        }
+
+        self.menu.style[self.side] = null;
+        self.panel.style.transform = null;
+
+        if (self.closed || self.closing) {
+          clearTimeout(self._timer);
+
+          self.menu.classList.add('open');
+          self.closed = false;
+          self.closing = false;
+          self.opened = false;
+          self.opening = true;
+
+          self._timer = setTimeout(function () {
+            self.opening = false;
+            self.opened = true;
+
+            self._trigger('opened');
+            html.classList.add('slit-open');
+            html.classList.add('slit-open-' + self._id);
+          }, self.timing);
+        }
+      },
+      /**
+       * Toggle the state of the menu
+       * @param {boolean} [condition] - `true` for open, `false` for close
+       */
+      toggle: function (condition) {
+        if (condition === true) {
+          this.open();
+        } else if (condition === false) {
+          this.close();
+        } else {
+          this.toggle(this.closed || this.closing);
+        }
+      },
+
+      /** @type {string[]} */
+      _ignores: [],
+      /**
+       * Ignore touch events from elements matching a given selector
+       * @param {string} selector
+       */
+      ignore: function (selector) {
+        this._ignores.push(selector);
+      },
+
+      _disabled: false,
+
+      /**
+       * Disable this menu
+       */
+      disable: function () {
+        this._disabled = true;
+      },
+      /**
+       * Enable this menu
+       */
+      enable: function () {
+        this._disabled = false;
+      },
+
+      _touched: false,
+      _menuStyle: getComputedStyle(options.menu),
+      _panelStyle: getComputedStyle(options.panel),
+      _offset: function () {
+        if (this.type === 'drawer') {
+          return parseFloat(this._menuStyle[this.side].match(/-?(\d+)px/)[1], 10);
+        } else {
+          var offset = this._panelStyle.transform.match(/matrix\((.*)\)/);
+          offset = offset && offset[1] && offset[1].split(', ')[4];
+          offset = offset ? Math.abs(parseFloat(offset, 10)) : 0;
+          return this.width - offset;
+        }
+      },
+      _startOffset: 0,
+      _startX: 0,
+
+      _id: uuid(),
+      _init: function () {
+        var self = this;
+
+        /** @type {Element} */
+        var menu = self.menu;
+        /** @type {Element} */
+        var panel = self.panel;
+
+        // setup CSS styles
+        menu.classList.add('slit');
+        menu.classList.add('slit-' + self._id);
+
+        panel.classList.add('slit-panel');
+        panel.classList.add('slit-panel-' + self._id);
+
+        var styleElem = document.getElementById('slit-styles');
+        if (!styleElem) {
+          document.head.insertAdjacentHTML('beforeend',
+            '<style id="slit-styles">' +
+            '.slit { position: fixed; top: 0; bottom: 0; left: auto; right: auto; }' +
+            '</style>'
+          );
+          styleElem = document.getElementById('slit-styles');
+        }
+
+        var style = '.slit-' + self._id + ' { transition: ' + self.side + ' ' + self.timing + 'ms; width: ' + self.width + 'px; ';
+        if (self.type === 'drawer') {
+          style += self.side + ': ' + -self.width + 'px; z-index: 10000; } .slit-' + self._id + '.open { ' + self.side + ': 0; }';
+        } else {
+          style += self.side + ': 0; } .slit-' + self._id + '.open ~ .slit-panel-' + self._id +
+            ' { transform: translateX(' + (self.side === 'left' ? '' : '-') + self.width + 'px); } ' +
+            '.slit-panel-' + self._id + ' { transform: translateX(0); transition: transform ' + self.timing + 'ms; }';
+        }
+        styleElem.insertAdjacentHTML('beforeend', style);
+
+        // setup events
+
+        /** @param {TouchEvent} e */
+        function onTouchstart(e) {
+          var ignores = self._ignores.join(', ');
+          if (ignores && e.target.matches(ignores)) {
+            return;
+          }
+          self._trigger('touchstart', e);
+          if (self._disabled) {
+            return;
+          }
+          if (self.closed) {
+            self._trigger('beforeopen');
+          } else if (self.opened) {
+            self._trigger('beforeclose');
+          }
+
+          self._touched = false;
+          if (e.touches.length === 1) {
+            var touch = e.touches[0];
+            var offset = self._offset();
+            var margin = self.margin + self.width - offset;
+            if (self.side === 'left' && touch.clientX <= margin ||
+                self.side === 'right' && window.innerWidth - touch.clientX <= margin) {
+              self._touched = true;
+              self._startX = touch.clientX;
+              self._startOffset = offset;
+            }
+          }
+        }
+
+        var lastOffset = self.width;
+
+        /** @param {TouchEvent} e */
+        function onTouchmove(e) {
+          self._trigger('touchmove', e);
+          if (self._disabled || !self._touched) {
+            return;
+          }
+
+          var touch = e.touches[0];
+          var diff = (self.side === 'left' ? -1 : 1) * (touch.clientX - self._startX);
+          var offset = Math.min(Math.max(0, self._startOffset + diff), self.width);
+          if (self.type === 'drawer') {
+            menu.style[self.side] = -offset + 'px';
+          } else {
+            panel.style.transform = 'translateX(' + (self.side === 'left' ? '' : '-') + (self.width - offset) + 'px)';
+          }
+          lastOffset = offset;
+        }
+
+        /** @param {TouchEvent} e */
+        function onTouchend(e) {
+          if (!self._touched) {
+            return;
+          }
+          self._trigger('touchend', e);
+
+          var offset = lastOffset;
+          if (offset > self.width * 2 / 3) {
+            self.close();
+          } else {
+            self.open();
+          }
+        }
+
+        html.addEventListener('touchstart', onTouchstart, false);
+        html.addEventListener('touchmove', onTouchmove, false);
+        html.addEventListener('touchend', onTouchend, false);
+      },
+    };
+
+    slit._init();
+
+    return slit;
+  }
+
+  return Slit;
+});

--- a/lib/slit.js
+++ b/lib/slit.js
@@ -93,7 +93,7 @@
        * maximum ratio of vertical touch movement to horizontal touch
        * movement that should be accepted
        */
-      slope: options.slope || 0.25,
+      slope: options.slope || 0.5,
 
       /**
        * @type {{ [key: string]: Function[] }}
@@ -163,12 +163,15 @@
           self.closed = false;
           self.closing = true;
 
+          html.dataset.slit = 'closing';
+          html.dataset.slitID = self._id;
+
           self._timer = setTimeout(function () {
             self.closing = false;
             self.closed = true;
 
-            html.classList.remove('slit-open');
-            html.classList.remove('slit-open-' + self._id);
+            html.dataset.slit = 'closed';
+            delete html.dataset.slitID;
             self._trigger('closed');
           }, self.timing);
         }
@@ -196,13 +199,16 @@
           self.opened = false;
           self.opening = true;
 
+          html.dataset.slit = 'opening';
+          html.dataset.slitID = self._id;
+
           self._timer = setTimeout(function () {
             self.opening = false;
             self.opened = true;
 
             self._trigger('opened');
-            html.classList.add('slit-open');
-            html.classList.add('slit-open-' + self._id);
+            html.dataset.slit = 'opened';
+            html.dataset.slitID = self._id;
           }, self.timing);
         }
       },
@@ -379,9 +385,13 @@
           if (offset > lastOffset) {
             self.opening = false;
             self.closing = true;
+            html.dataset.slit = 'closing';
+            html.dataset.slitID = self._id;
           } else {
             self.opening = true;
             self.closing = false;
+            html.dataset.slit = 'opening';
+            html.dataset.slitID = self._id;
           }
 
           if (self.type === 'drawer') {

--- a/lib/slit.js
+++ b/lib/slit.js
@@ -312,6 +312,8 @@
               self._touched = true;
               self._startX = touch.clientX;
               self._startOffset = offset;
+              menu.style.transition = 'none';
+              panel.style.transition = 'none';
             }
           }
         }
@@ -349,6 +351,8 @@
           } else {
             self.open();
           }
+          menu.style.transition = null;
+          panel.style.transition = null;
         }
 
         html.addEventListener('touchstart', onTouchstart, false);

--- a/lib/slit.js
+++ b/lib/slit.js
@@ -346,11 +346,12 @@
           self._trigger('touchend', e);
 
           var offset = lastOffset;
-          if (offset > self.width * 2 / 3) {
+          if (offset > self.width / 2) {
             self.close();
           } else {
             self.open();
           }
+          self._touched = false;
           menu.style.transition = null;
           panel.style.transition = null;
         }

--- a/lib/slit.js
+++ b/lib/slit.js
@@ -287,6 +287,8 @@
         var startX = 0;
         var startOffset = 0;
         var lastOffset = self.width;
+        var lastTime = Date.now();
+        var lastVel = 0;
         var firstMove = false;
 
         /** @param {TouchEvent} e */
@@ -354,6 +356,9 @@
           } else {
             panel.style.transform = 'translateX(' + (self.side === 'left' ? '' : '-') + (self.width - offset) + 'px)';
           }
+          var time = Date.now();
+          lastVel = (offset - lastOffset) / (time - lastTime);
+          lastTime = time;
           lastOffset = offset;
         }
 
@@ -365,7 +370,7 @@
           self._trigger('touchend', e);
 
           var offset = lastOffset;
-          if (offset > self.width / 2) {
+          if (offset > self.width / 2 && lastVel > -0.25 || lastVel > 0.25) {
             self.close();
           } else {
             self.open();

--- a/lib/slit.js
+++ b/lib/slit.js
@@ -360,16 +360,6 @@
           var touch = e.touches[0];
           var diff = (self.side === 'left' ? -1 : 1) * (touch.clientX - startX);
 
-          if (firstMove) {
-            if (self.closed && diff < 0) {
-              self._trigger('beforeopen');
-            } else if (self.opened) {
-              self._trigger('beforeclose');
-            }
-            menu.style.transition = 'none';
-            panel.style.transition = 'none';
-          }
-
           var offset = Math.min(Math.max(0, startOffset + diff), self.width);
 
           if (firstMove) {
@@ -378,6 +368,14 @@
               self._touched = false;
               return;
             }
+
+            if (self.closed && diff < 0) {
+              self._trigger('beforeopen');
+            } else if (self.opened) {
+              self._trigger('beforeclose');
+            }
+            menu.style.transition = 'none';
+            panel.style.transition = 'none';
           }
 
           self.opened = false;

--- a/lib/slit.js
+++ b/lib/slit.js
@@ -362,8 +362,12 @@
 
           var offset = Math.min(Math.max(0, startOffset + diff), self.width);
 
+          if (Math.abs(diff) < 20) {
+            return;
+          }
+
           if (firstMove) {
-            var slope = Math.abs(touch.clientY - lastY) / Math.abs(offset - lastOffset);
+            var slope = Math.abs(touch.clientY - lastY) / Math.abs(diff);
             if (slope > self.slope) {
               self._touched = false;
               return;

--- a/lib/slit.js
+++ b/lib/slit.js
@@ -31,7 +31,7 @@
   /**
    * @exports Slit
    * Create a Slit instance
-   * @param {{ menu: Element, panel: Element, side: string, margin: number }} options
+   * @param {{}} options
    */
   function Slit(options) {
     assert(options.menu instanceof Element);
@@ -41,6 +41,8 @@
     assert(!options.margin || isFinite(options.margin));
     assert(!options.timing || isFinite(options.timing));
     assert(!options.width || isFinite(options.width));
+    assert(!options.sensitivity || isFinite(options.sensitivity));
+    assert(!options.slope || isFinite(options.slope));
 
     var html = document.documentElement;
 
@@ -81,6 +83,17 @@
        * width of menu in pixels
        */
       width: options.width || 256,
+      /**
+       * @type {number}
+       * the velocity needed to activate a flick
+       */
+      sensitivity: options.sensitivity || 0.25,
+      /**
+       * @type {number}
+       * maximum ratio of vertical touch movement to horizontal touch
+       * movement that should be accepted
+       */
+      slope: options.slope || 0.25,
 
       /**
        * @type {{ [key: string]: Function[] }}
@@ -207,8 +220,12 @@
         }
       },
 
-      /** @type {string[]} */
+      /**
+       * @private
+       * @type {string[]}
+       */
       _ignores: [],
+
       /**
        * Ignore touch events from elements matching a given selector
        * @param {string} selector
@@ -217,6 +234,7 @@
         this._ignores.push(selector);
       },
 
+      /** @private */
       _disabled: false,
 
       /**
@@ -232,9 +250,13 @@
         this._disabled = false;
       },
 
+      /** @private */
       _touched: false,
+      /** @private */
       _menuStyle: getComputedStyle(options.menu),
+      /** @private */
       _panelStyle: getComputedStyle(options.panel),
+      /** @private */
       _offset: function () {
         if (this.type === 'drawer') {
           return parseFloat(this._menuStyle[this.side].match(/-?(\d+)px/)[1], 10);
@@ -246,7 +268,9 @@
         }
       },
 
+      /** @private */
       _id: uuid(),
+      /** @private */
       _init: function () {
         var self = this;
 
@@ -289,6 +313,7 @@
         var lastOffset = self.width;
         var lastTime = Date.now();
         var lastVel = 0;
+        var lastY = 0;
         var firstMove = false;
 
         /** @param {TouchEvent} e */
@@ -311,6 +336,7 @@
                 self.side === 'right' && window.innerWidth - touch.clientX <= margin) {
               self._touched = true;
               startX = touch.clientX;
+              lastY = touch.clientY;
               startOffset = offset;
               lastOffset = offset;
               firstMove = true;
@@ -326,8 +352,6 @@
           }
 
           if (firstMove) {
-            firstMove = false;
-
             if (self.closed) {
               self._trigger('beforeopen');
             } else if (self.opened) {
@@ -340,6 +364,14 @@
           var touch = e.touches[0];
           var diff = (self.side === 'left' ? -1 : 1) * (touch.clientX - startX);
           var offset = Math.min(Math.max(0, startOffset + diff), self.width);
+
+          if (firstMove) {
+            var slope = Math.abs(touch.clientY - lastY) / Math.abs(offset - lastOffset);
+            if (slope > self.slope) {
+              self._touched = false;
+              return;
+            }
+          }
 
           self.opened = false;
           self.closed = false;
@@ -356,10 +388,12 @@
           } else {
             panel.style.transform = 'translateX(' + (self.side === 'left' ? '' : '-') + (self.width - offset) + 'px)';
           }
+
           var time = Date.now();
           lastVel = (offset - lastOffset) / (time - lastTime);
           lastTime = time;
           lastOffset = offset;
+          firstMove = false;
         }
 
         /** @param {TouchEvent} e */
@@ -370,7 +404,7 @@
           self._trigger('touchend', e);
 
           var offset = lastOffset;
-          if (offset > self.width / 2 && lastVel > -0.25 || lastVel > 0.25) {
+          if (offset > self.width / 2 && lastVel > -self.sensitivity || lastVel > self.sensitivity) {
             self.close();
           } else {
             self.open();

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/psychobunny/nodebb-theme-persona/issues"
+  },
+  "dependencies": {
+    "slideout": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
   "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/psychobunny/nodebb-theme-persona/issues"
-  },
-  "dependencies": {
-    "slideout": "^1.0.1"
   }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -17,7 +17,7 @@
 		"lib/client/chats.js"
 	],
 	"modules": {
-		"slideout.js": "node_modules/slideout/dist/slideout.min.js"
+		"slit.js": "lib/slit.js"
 	},
 	"acpScripts": [
 		"lib/admin.js"

--- a/plugin.json
+++ b/plugin.json
@@ -13,10 +13,12 @@
 		"lib/persona.js",
 		"lib/modules/nprogress.js",
 		"lib/modules/autohidingnavbar.min.js",
-		"lib/modules/slideout.min.js",
 		"lib/modules/quickreply.js",
 		"lib/client/chats.js"
 	],
+	"modules": {
+		"slideout.js": "node_modules/slideout/dist/slideout.min.js"
+	},
 	"acpScripts": [
 		"lib/admin.js"
 	]

--- a/templates/header.tpl
+++ b/templates/header.tpl
@@ -31,7 +31,7 @@
 </head>
 
 <body class="{bodyClass} skin-{config.bootswatchSkin}">
-	<nav id="menu" class="hidden">
+	<nav id="menu" class="hidden slideout-menu">
 		<section class="menu-profile">
 			<!-- IF user.uid -->
 			<!-- IF user.picture -->
@@ -65,7 +65,7 @@
 		<!-- ENDIF config.loggedIn -->
 	</nav>
 
-	<nav class="hidden" id="chats-menu">
+	<nav id="chats-menu" class="hidden slideout-menu">
 		<!-- IF config.loggedIn -->
 		<section class="menu-section">
 			<h3 class="menu-section-title">

--- a/templates/header.tpl
+++ b/templates/header.tpl
@@ -62,8 +62,12 @@
 			<ul class="menu-section-list notification-list-mobile" component="notifications/list"></ul>
 			<p class="menu-section-list"><a href="{relative_path}/notifications">[[notifications:see_all]]</a></p>
 		</section>
+		<!-- ENDIF config.loggedIn -->
+	</nav>
 
-		<section class="menu-section" data-section="chats">
+	<nav class="hidden" id="chats-menu">
+		<!-- IF config.loggedIn -->
+		<section class="menu-section">
 			<h3 class="menu-section-title">
 				[[global:header.chats]]
 				<i class="counter" component="chat/icon" data-content="0"></i>

--- a/templates/partials/menu.tpl
+++ b/templates/partials/menu.tpl
@@ -1,9 +1,13 @@
 			<div class="navbar-header">
-				<button type="button" class="navbar-toggle" id="mobile-menu">
+				<button type="button" class="navbar-toggle pull-left" id="mobile-menu">
 					<span component="notifications/icon" class="notification-icon fa fa-fw fa-bell-o" data-content="0"></span>
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
+				</button>
+				<button type="button" class="navbar-toggle" id="mobile-chats">
+					<span component="chat/icon" class="notification-icon fa fa-fw fa-comments" data-content="0"></span>
+					<i class="fa fa-comment-o"></i>
 				</button>
 
 				<a href="<!-- IF brand:logo:url -->{brand:logo:url}<!-- ELSE -->{relative_path}/<!-- ENDIF brand:logo:url -->">

--- a/templates/partials/menu.tpl
+++ b/templates/partials/menu.tpl
@@ -5,7 +5,7 @@
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 				</button>
-				<button type="button" class="navbar-toggle" id="mobile-chats">
+				<button type="button" class="navbar-toggle hidden" id="mobile-chats">
 					<span component="chat/icon" class="notification-icon fa fa-fw fa-comments" data-content="0"></span>
 					<i class="fa fa-comment-o"></i>
 				</button>


### PR DESCRIPTION
- Move Slideout library to an rjs module from npm
- Moved normal menu to the left side, as is normal elsewhere
- Added chat button on right side
- Unread icon on it shows unread chats
- Added slideout menu on right for only chats
- Button is the only way to open it
  due to incompatibilities with double draggable Slideouts

### Screenshots
![image](https://cloud.githubusercontent.com/assets/803701/26770976/417b8c48-4978-11e7-889e-52fc382a496f.png)
![image](https://cloud.githubusercontent.com/assets/803701/26770980/559b4b3c-4978-11e7-9f2a-eb56a20f6ba5.png)
![image](https://cloud.githubusercontent.com/assets/803701/26770988/623b2d6c-4978-11e7-8f11-8e4ac945ded9.png)
