### PR TITLE
Add settings page to control watched categories

### DIFF
--- a/templates/account/categories.tpl
+++ b/templates/account/categories.tpl
@@ -1,0 +1,15 @@
+<div class="account">
+	<!-- IMPORT partials/account/header.tpl -->
+
+	<div class="row">
+		<h1>{title}</h1>
+
+		<div class="col-lg-12">
+			<ul class="categories" itemscope itemtype="http://www.schema.org/ItemList">
+				<!-- BEGIN categories -->
+				<!-- IMPORT partials/account/category-item.tpl -->
+				<!-- END categories -->
+			</ul>
+		</div>
+	</div>
+</div>

--- a/templates/partials/account/category-item.tpl
+++ b/templates/partials/account/category-item.tpl
@@ -1,0 +1,22 @@
+<li component="categories/category" data-cid="{../cid}" data-parent-cid="{../parentCid}" class="row clearfix">
+	<meta itemprop="name" content="{../name}">
+
+	<div class="content col-xs-12 col-md-10 col-sm-12">
+		<div class="icon pull-left" style="{function.generateCategoryBackground}">
+			<i class="fa fa-fw {../icon}"></i>
+		</div>
+
+		<h2 class="title">
+			<!-- IMPORT partials/categories/link.tpl -->
+		</h2>
+		<div>
+			<!-- IF ../descriptionParsed -->
+			<div class="description">
+				{../descriptionParsed}
+			</div>
+			<!-- ENDIF ../descriptionParsed -->
+		</div>
+	</div>
+
+	<!-- IMPORT partials/category/watch.tpl -->
+</li>

--- a/templates/partials/account/menu.tpl
+++ b/templates/partials/account/menu.tpl
@@ -28,6 +28,7 @@
 		<!-- IF showHidden -->
 		<li><a href="{config.relative_path}/user/{userslug}/edit">[[user:edit]]</a></li>
 		<li><a href="{config.relative_path}/user/{userslug}/settings">[[user:settings]]</a></li>
+		<li><a href="{config.relative_path}/user/{userslug}/categories">[[user:watched_categories]]</a></li>
 		<!-- ENDIF showHidden -->
 
 		<!-- IF !isSelf -->

--- a/templates/partials/category/watch.tpl
+++ b/templates/partials/category/watch.tpl
@@ -3,16 +3,16 @@
 
 	<button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button">
 
-		<span component="category/watching/menu" <!-- IF isIgnored -->class="hidden"<!-- ENDIF isIgnored -->><i class="fa fa-fw fa-eye"></i><span class="visible-sm-inline visible-md-inline visible-lg-inline">[[category:watching]]</span></span>
+		<span component="category/watching/menu" <!-- IF isIgnored -->class="hidden"<!-- ENDIF isIgnored --><!-- IF ../isIgnored -->class="hidden"<!-- ENDIF ../isIgnored -->><i class="fa fa-fw fa-eye"></i><span class="visible-sm-inline visible-md-inline visible-lg-inline">[[category:watching]]</span></span>
 
-		<span component="category/ignoring/menu" <!-- IF !isIgnored -->class="hidden"<!-- ENDIF !isIgnored -->><i class="fa fa-fw fa-eye-slash"></i><span class="visible-sm-inline visible-md-inline visible-lg-inline">[[category:ignoring]]</span></span>
+		<span component="category/ignoring/menu" <!-- IF !../isIgnored --><!-- IF !isIgnored -->class="hidden"<!-- ENDIF !isIgnored --><!-- ENDIF !../isIgnored -->><i class="fa fa-fw fa-eye-slash"></i><span class="visible-sm-inline visible-md-inline visible-lg-inline">[[category:ignoring]]</span></span>
 
 		<span class="caret"></span>
 	</button>
 
 	<ul class="dropdown-menu dropdown-menu-right">
-		<li><a href="#" component="category/watching"><i component="category/watching/check" class="fa fa-fw <!-- IF !isIgnored -->fa-check<!-- ENDIF !isIgnored -->"></i><i class="fa fa-fw fa-eye"></i> [[category:watching]]<p class="help-text"><small>[[category:watching.description]]</small></p></a></li>
-		<li><a href="#" component="category/ignoring"><i component="category/ignoring/check" class="fa fa-fw <!-- IF isIgnored -->fa-check<!-- ENDIF isIgnored -->"></i><i class="fa fa-fw fa-eye-slash"></i> [[category:ignoring]]<p class="help-text"><small>[[category:ignoring.description]]</small></p></a></li>
+		<li><a href="#" component="category/watching"><i component="category/watching/check" class="fa fa-fw <!-- IF !../isIgnored --><!-- IF !isIgnored -->fa-check<!-- ENDIF !isIgnored --><!-- ENDIF !../isIgnored -->"></i><i class="fa fa-fw fa-eye"></i> [[category:watching]]<p class="help-text"><small>[[category:watching.description]]</small></p></a></li>
+		<li><a href="#" component="category/ignoring"><i component="category/ignoring/check" class="fa fa-fw <!-- IF isIgnored -->fa-check<!-- ENDIF isIgnored --><!-- IF ../isIgnored -->fa-check<!-- ENDIF ../isIgnored -->"></i><i class="fa fa-fw fa-eye-slash"></i> [[category:ignoring]]<p class="help-text"><small>[[category:ignoring.description]]</small></p></a></li>
 	</ul>
 </div>
 <!-- ENDIF config.loggedIn -->


### PR DESCRIPTION
This commit, together with the [pull request at NodeBB](https://github.com/NodeBB/NodeBB/pull/6648), adds a settings page to control your watched and ignored categories.

The page shows all categories in a flat view and the buttons do update as expected, changing the watched setting in a top level modifies the setting for all sub-categories.