### PR TITLE
Fixed the listing of custom profile info on posts

### DIFF
--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -36,9 +36,9 @@
 			<span>
 				<!-- IF posts.user.custom_profile_info.length -->
 				&#124;
-				<!-- BEGIN custom_profile_info -->
+				<!-- BEGIN posts.user.custom_profile_info -->
 				{posts.user.custom_profile_info.content}
-				<!-- END custom_profile_info -->
+				<!-- END posts.user.custom_profile_info -->
 				<!-- ENDIF posts.user.custom_profile_info.length -->
 			</span>
 		</span>


### PR DESCRIPTION
It missed the `posts.user.` prefix and thus never iterated over anything since it is an undefined variable.