### PR TITLE
Adding "See all chats" link to mobile chat slideout

### DIFF
--- a/templates/header.tpl
+++ b/templates/header.tpl
@@ -66,6 +66,7 @@
 				<i class="counter unread-count" component="chat/icon" data-content="{unreadCount.chat}"></i>
 			</h3>
 			<ul class="menu-section-list chat-list" component="chat/list"></ul>
+			<a href="{relative_path}/user/{user.userslug}/chats">[[modules:chat.see_all]]</a>
 		</section>
 		<!-- ENDIF config.loggedIn -->
 	</nav>


### PR DESCRIPTION
# Overview
The chats dropdown and chat slideout only display the 10 most recent chats. For desktop viewing, there is a "See all chats" button that solves the issue of seeing all of a users chat by navigating to the chats page. On mobile, there is no such button. This forces users to manually type in the url to get to the chats page in order to see more than the 10 most recent chats.

This PR adds a link to the chats page in the mobile chats slide out drawer.

# Testing
Used against two local versions of NodeBB installed, one at 1.7.5 and the other at 1.9.3, both used for testing a previous migration script that I wrote. I don't have an in depth knowledge of what changes between versions but the variables used could be confirmed that they were not removed in later versions of NodeBB:

1. `relative_path`: okay, used in the same file
2. `user.userslug`: okay, used in other files
3. `[[modules:chat.see_all]]`: okay, used in **templates/partials/menu.tpl**

# Preview

![nodebb-see-all-chats-mobile](https://user-images.githubusercontent.com/1718706/44124260-251db5a6-9fe1-11e8-933d-5af50eaa5ba4.gif)
