### PR TITLE
Move chat icons above message

### DIFF
--- a/less/chats.less
+++ b/less/chats.less
@@ -451,6 +451,11 @@
 				.user-select(none);
 			}
 
+			.chat-ip, .chat-edited {
+				margin-left: 5px;
+				margin-top: 2px;
+			}
+
 			.message-body {
 				margin-left: 45px;
 				overflow-y: hidden;

--- a/templates/partials/chats/message.tpl
+++ b/templates/partials/chats/message.tpl
@@ -16,12 +16,10 @@
 		<!-- END -->
 		<span class="chat-timestamp timeago" title="{messages.timestampISO}"></span>
 		<!-- IF isAdminOrGlobalMod -->
-		<small class="chat-ip pull-right" title="[[modules:chat.show-ip]]"><i class="fa fa-info-circle chat-ip-button"></i></small>
+		<div class="chat-ip pull-right" title="[[modules:chat.show-ip]]"><i class="fa fa-info-circle chat-ip-button"></i></div>
 		<!-- ENDIF isAdminOrGlobalMod -->
-	</div>
-	<div component="chat/message/body" class="message-body">
 		<!-- IF messages.edited -->
-		<small class="text-muted pull-right" title="[[global:edited]] {messages.editedISO}"><i class="fa fa-edit"></i></span></small>
+		<div class="text-muted pull-right" title="[[global:edited]] {messages.editedISO}"><i class="fa fa-edit"></i></span></div>
 		<!-- ENDIF messages.edited -->
 		<!-- IF !config.disableChatMessageEditing -->
 		<!-- IF messages.self -->
@@ -32,6 +30,8 @@
 		</div>
 		<!-- ENDIF messages.self -->
 		<!-- ENDIF !config.disableChatMessageEditing -->
+	</div>
+	<div component="chat/message/body" class="message-body">
 		{messages.content}
 	</div>
 </li>


### PR DESCRIPTION
This change moves the many icons that can possibly show in chat messages to a less obstructive place, most especially for the editing icons, to make hovering/editing messages less annoying.

Before:
![Bad. Icons move the text.](https://user-images.githubusercontent.com/2224730/45240309-8df56480-b2be-11e8-9f38-2bdd8cad64e5.gif)

Now:
![Good. Text remains in place.](https://user-images.githubusercontent.com/2224730/45240320-9483dc00-b2be-11e8-976a-2e4ce28c0a11.gif)

All icons:
![All icons showing](https://user-images.githubusercontent.com/2224730/45240326-9cdc1700-b2be-11e8-91ed-e70787140e9b.png)
