### PR TITLE
Added German translation for persona:mobile-menu-side

### DIFF
--- a/languages/de/persona.json
+++ b/languages/de/persona.json
@@ -1,0 +1,3 @@
+{
+    "mobile-menu-side": "Menüposition der mobilen Seiten umschalten"
+}


### PR DESCRIPTION
Providing the German translation for `persona:mobile-menu-side` thanks to the fixing of issue #418.