### PR TITLE
Move chat icons to the left of the message

### DIFF
--- a/less/chats.less
+++ b/less/chats.less
@@ -457,14 +457,15 @@
 				.user-select(none);
 			}
 
-			.chat-ip, .chat-edited {
-				margin-left: 5px;
-				margin-top: 2px;
+			.chat-edited {
+				position: absolute;
+				top: 2px;
+				left: -20px;
 			}
 
 			.message-body {
+				position: relative;
 				margin-left: 45px;
-				overflow-y: hidden;
 
 				p {
 					margin: 7px 0 0 0;
@@ -482,6 +483,9 @@
 
 			.controls {
 				display: none;
+				position: absolute;
+				top: 0;
+				left: -43px;
 
 				[data-action="restore"] {
 					display: none;
@@ -491,6 +495,9 @@
 			&:hover {
 				.controls {
 					display: block;
+				}
+				.chat-edited {
+					display: none;
 				}
 			}
 		}

--- a/templates/partials/chats/message.tpl
+++ b/templates/partials/chats/message.tpl
@@ -18,20 +18,20 @@
 		<!-- IF isAdminOrGlobalMod -->
 		<div class="chat-ip pull-right" title="[[modules:chat.show-ip]]"><i class="fa fa-info-circle chat-ip-button"></i></div>
 		<!-- ENDIF isAdminOrGlobalMod -->
+	</div>
+	<div component="chat/message/body" class="message-body">
 		<!-- IF messages.edited -->
-		<div class="text-muted pull-right" title="[[global:edited]] {messages.editedISO}"><i class="fa fa-edit"></i></span></div>
+		<div class="chat-edited" title="[[global:edited]] {messages.editedISO}"><i class="fa fa-edit"></i></span></div>
 		<!-- ENDIF messages.edited -->
 		<!-- IF !config.disableChatMessageEditing -->
 		<!-- IF messages.self -->
-		<div class="pull-right btn-group controls">
+		<div class="btn-group controls">
 			<button class="btn btn-xs btn-link" data-action="edit"><i class="fa fa-pencil"></i></button>
 			<button class="btn btn-xs btn-link" data-action="delete"><i class="fa fa-times"></i></button>
 			<button class="btn btn-xs btn-link" data-action="restore"><i class="fa fa-repeat"></i></button>
 		</div>
 		<!-- ENDIF messages.self -->
 		<!-- ENDIF !config.disableChatMessageEditing -->
-	</div>
-	<div component="chat/message/body" class="message-body">
 		{messages.content}
 	</div>
 </li>


### PR DESCRIPTION
This is a fix to pull #429 because if you send consecutive messages those will not contain the header, thus making it impossible to edit or delete those messages.

The solution is either a complete revert of commit 2746ecf or to instead use this commit that will move the icons to the left.

![newlocation](https://user-images.githubusercontent.com/2224730/46980368-b4bb6d80-d0aa-11e8-8091-d515e650510a.png)
