### PR TITLE
Adding at least a tiny bit of accessibility to the New Topic button

### DIFF
--- a/templates/partials/buttons/newTopic.tpl
+++ b/templates/partials/buttons/newTopic.tpl
@@ -1,5 +1,5 @@
 <noscript><div class="dropdown" component="category-selector"></noscript>
-<label component="category/post" for="category-dropdown-check" class="btn btn-primary" id="new_topic">
+<label component="category/post" for="category-dropdown-check" class="btn btn-primary" id="new_topic" role="button">
 	[[category:new_topic_button]]
 </label>
 <noscript>


### PR DESCRIPTION
I don't have the time to look into this enough to really make the "New Topic" button accessible. However, right now, it isn't accessible for keyboard navigation at all (as it's not registered as "clickable").

While these changes don't add actual "overall" accessibility to the pseudo button, it at least adds the ability for keyboard navigation tools to register it as a button (at least adding support for extensions like [Vimium](https://vimium.github.io/), etc.


## Screenshots using the Vimium Extension
### Before
![image](https://user-images.githubusercontent.com/25147704/88452920-f887fd00-ce62-11ea-91b5-d8c77eaecca1.png)


### After
![image](https://user-images.githubusercontent.com/25147704/88452906-d9896b00-ce62-11ea-9d6a-1a2fb93f9c3e.png)

(the button is now "clickable" using the keyboard)
