### PR TITLE
Timeline-style design for a topic's posts

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -47,3 +47,19 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+
+.timeline {
+	.posts [component="post"], .necro-post {
+		border-left: 2px solid lighten(@brand-primary, 30%);
+
+		margin-left: 2.5rem;
+
+		&:not(:last-child) {
+			padding-bottom: @post-padding;
+		}
+
+		> div {
+			margin-left: -2.5rem;
+		}
+	}
+}

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -50,7 +50,7 @@
 
 .timeline {
 	@media (min-width: @screen-md-min) {
-		.posts > [component="post"], .necro-post {
+		.posts > [component="post"], .timeline-event {
 			border-left: 2px solid lighten(@brand-primary, 30%);
 
 			margin-left: 2.5rem;
@@ -68,6 +68,30 @@
 				position: relative;
 				z-index: 1;
 				box-shadow: 0 0 0 .5rem @body-bg;
+			}
+		}
+
+		.posts .timeline-event {
+			text-align: left;
+			font-size: 1em;
+
+			.timeline-badge {
+				float: left;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				width: 32px;
+				height: 32px;
+				margin-left: -17px;
+				margin-right: 17px;
+				color: lighten(@brand-primary, 30%);
+				background-color: @body-bg;
+				border: 2px solid lighten(@brand-primary, 30%);
+				border-radius: 50%;
+			}
+
+			.timeline-text {
+				line-height: 32px;
 			}
 		}
 	}

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -62,6 +62,13 @@
 			> div {
 				margin-left: -2.5rem;
 			}
+
+			.avatar, .timeline-badge {
+				// Opaque ring
+				position: relative;
+				z-index: 1;
+				box-shadow: 0 0 0 .5rem @body-bg;
+			}
 		}
 	}
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -49,17 +49,19 @@
 }
 
 .timeline {
-	.posts [component="post"], .necro-post {
-		border-left: 2px solid lighten(@brand-primary, 30%);
+	@media (min-width: @screen-md-min) {
+		.posts [component="post"], .necro-post {
+			border-left: 2px solid lighten(@brand-primary, 30%);
 
-		margin-left: 2.5rem;
+			margin-left: 2.5rem;
 
-		&:not(:last-child) {
-			padding-bottom: @post-padding;
-		}
+			&:not(:last-child) {
+				padding-bottom: @post-padding;
+			}
 
-		> div {
-			margin-left: -2.5rem;
+			> div {
+				margin-left: -2.5rem;
+			}
 		}
 	}
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -50,7 +50,7 @@
 
 .timeline {
 	@media (min-width: @screen-md-min) {
-		.posts [component="post"], .necro-post {
+		.posts > [component="post"], .necro-post {
 			border-left: 2px solid lighten(@brand-primary, 30%);
 
 			margin-left: 2.5rem;

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -122,9 +122,8 @@
 	}
 
 	.posts .timeline-event {
-		display: flex;
-		align-items: center;
 		text-align: left;
+		justify-content: left;
 		font-size: 1em;
 
 		.timeline-badge {
@@ -134,6 +133,7 @@
 			justify-content: center;
 			width: 32px;
 			height: 32px;
+			padding: 0;
 			margin-left: -17px;
 			margin-right: 17px;
 			color: lighten(@brand-primary, 30%);

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -74,6 +74,10 @@
 			}
 		}
 
+		.necro-post {
+			border-left-style: dashed;
+		}
+
 		.posts [component="post"]:last-child:after {
 			content: '';
 			width: 1rem;

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -146,10 +146,6 @@
 			line-height: 32px;
 			text-transform: initial;
 			color: rgba(127,127,127,.5);
-
-			&:not(:last-child) {
-				margin-right: .5rem;
-			}
 		}
 	}
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -49,73 +49,106 @@
 }
 
 .timeline {
-	@media (min-width: @screen-md-min) {
-		.posts > [component="post"], .timeline-event {
-			border-left: 2px solid lighten(@brand-primary, 30%);
+	.posts > [component="post"], .timeline-event {
+		position: relative;	// for absolutely positioned pseudo-element, below
+		border-left: 2px solid lighten(@brand-primary, 30%);
+		margin-left: 2.5rem;
 
-			margin-left: 2.5rem;
-
-			&:not(:last-child) {
-				padding-bottom: @post-padding;
-			}
-			&:not(:first-child) {
-				padding-top: @post-padding;
-			}
-
-			> div {
-				margin-left: -2.5rem;
-			}
-
-			.avatar, .timeline-badge {
-				// Opaque ring
-				position: relative;
-				z-index: 1;
-				box-shadow: 0 0 0 .5rem @body-bg;
-			}
+		&:not(:last-child) {
+			padding-bottom: @post-padding;
+		}
+		&:not(:first-child) {
+			padding-top: @post-padding;
 		}
 
-		.necro-post {
-			border-left-style: dashed;
+		> div {
+			margin-left: -2.5rem;
+		}
+
+		.avatar, .timeline-badge {
+			// Opaque ring
+			position: relative;
+			z-index: 1;
+			box-shadow: 0 0 0 .5rem @body-bg;
+		}
+	}
+
+	@media (max-width: @screen-sm-max) {
+		.posts > [component="post"] {
+			border: 0;
+			padding: @post-padding 0;
+
+			margin-left: initial;
+			> div {
+				margin-left: 1.5rem;
+			}
 		}
 
 		.posts [component="post"]:last-child:after {
-			content: '';
-			width: 1rem;
-			position: absolute;
-			bottom: 0;
-			left: calc(-0.5rem - 1px);
-			border-bottom: 2px solid lighten(@brand-primary, 30%);
+			display: none;
 		}
 
-		.posts .timeline-event {
-			display: flex;
-			align-items: center;
-			text-align: left;
-			font-size: 1em;
-
-			.timeline-badge {
-				float: left;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				width: 32px;
-				height: 32px;
-				margin-left: -17px;
-				margin-right: 17px;
-				color: lighten(@brand-primary, 30%);
-				background-color: @body-bg;
-				border: 2px solid lighten(@brand-primary, 30%);
-				border-radius: 50%;
+		.timeline-event {
+			&:before, &+:not(.timeline-event):before {
+				content: '';
+				width: 1rem;
+				position: absolute;
+				top: 0;
+				left: calc(-0.5rem - 1px);
+				border-bottom: 2px solid lighten(@brand-primary, 30%);
 			}
 
-			.timeline-text {
-				line-height: 32px;
-				text-transform: initial;
-				color: rgba(127,127,127,.5);
+			&+:not(.timeline-event):before {
+				left: calc(2rem + 1px);
+			}
 
-				&:not(:last-child) {
-					margin-right: .5rem;
-				}
+			&+.timeline-event:before {
+				display: none;
+			}
+		}
+	}
+
+	.necro-post {
+		border-left-style: dashed;
+	}
+
+	.posts [component="post"]:last-child:after {
+		content: '';
+		width: 1rem;
+		position: absolute;
+		bottom: 0;
+		left: calc(-0.5rem - 1px);
+		border-bottom: 2px solid lighten(@brand-primary, 30%);
+	}
+
+	.posts .timeline-event {
+		display: flex;
+		align-items: center;
+		text-align: left;
+		font-size: 1em;
+
+		.timeline-badge {
+			float: left;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 32px;
+			height: 32px;
+			margin-left: -17px;
+			margin-right: 17px;
+			color: lighten(@brand-primary, 30%);
+			background-color: @body-bg;
+			border: 2px solid lighten(@brand-primary, 30%);
+			border-radius: 50%;
+		}
+
+		.timeline-text {
+			line-height: 32px;
+			text-transform: initial;
+			color: rgba(127,127,127,.5);
+
+			&:not(:last-child) {
+				margin-right: .5rem;
 			}
 		}
 	}

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -58,6 +58,9 @@
 			&:not(:last-child) {
 				padding-bottom: @post-padding;
 			}
+			&:not(:first-child) {
+				padding-top: @post-padding;
+			}
 
 			> div {
 				margin-left: -2.5rem;
@@ -72,6 +75,8 @@
 		}
 
 		.posts .timeline-event {
+			display: flex;
+			align-items: center;
 			text-align: left;
 			font-size: 1em;
 
@@ -92,6 +97,12 @@
 
 			.timeline-text {
 				line-height: 32px;
+				text-transform: initial;
+				color: rgba(127,127,127,.5);
+
+				&:not(:last-child) {
+					margin-right: .5rem;
+				}
 			}
 		}
 	}

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -74,6 +74,15 @@
 			}
 		}
 
+		.posts [component="post"]:last-child:after {
+			content: '';
+			width: 1rem;
+			position: absolute;
+			bottom: 0;
+			left: calc(-0.5rem - 1px);
+			border-bottom: 2px solid lighten(@brand-primary, 30%);
+		}
+
 		.posts .timeline-event {
 			display: flex;
 			align-items: center;

--- a/less/modules/necro-post.less
+++ b/less/modules/necro-post.less
@@ -1,23 +1,38 @@
 .topic .necro-post {
+	text-align: center;
+	color: rgba(127,127,127,.5);
+	padding-bottom: @post-padding;
+
 	.timeline-badge {
-		float: left;
-		width: 32px;
-		height: 32px;
-		line-height: 32px;
-		margin-left: -17px;
-		margin-right: 17px;
-		color: lighten(@brand-primary, 30%);
-		background-color: @body-bg;
-		border: 2px solid lighten(@brand-primary, 30%);
-		border-radius: 50%;
-		text-align: center;
+		display: none;
 	}
 
 	span {
-		padding-bottom: @post-padding;
-		color: rgba(127,127,127,.5);
-		font-size: 1em;
+		font-size: 1.5em;
 		text-transform: uppercase;
-		line-height: 32px;
+	}
+
+	@media (min-width: @screen-md-min) {
+		text-align: left;
+
+		.timeline-badge {
+			float: left;
+			display: block;
+			width: 32px;
+			height: 32px;
+			line-height: 32px;
+			margin-left: -17px;
+			margin-right: 17px;
+			color: lighten(@brand-primary, 30%);
+			background-color: @body-bg;
+			border: 2px solid lighten(@brand-primary, 30%);
+			border-radius: 50%;
+			text-align: center;
+		}
+
+		span {
+			font-size: 1em;
+			line-height: 32px;
+		}
 	}
 }

--- a/less/modules/necro-post.less
+++ b/less/modules/necro-post.less
@@ -4,10 +4,6 @@
 	margin-bottom: 0;
 	font-size: 1.5em;
 
-	&:not(:last-child) {
-		padding-bottom: calc(@post-padding * 2);
-	}
-
 	.timeline-badge {
 		display: none;
 	}

--- a/less/modules/necro-post.less
+++ b/less/modules/necro-post.less
@@ -1,4 +1,23 @@
 .topic .necro-post {
-	border-bottom: 1px solid @post-border-color;
-	padding-bottom: @post-padding;
+	.timeline-badge {
+		float: left;
+		width: 32px;
+		height: 32px;
+		line-height: 32px;
+		margin-left: -17px;
+		margin-right: 17px;
+		color: lighten(@brand-primary, 30%);
+		background-color: @body-bg;
+		border: 2px solid lighten(@brand-primary, 30%);
+		border-radius: 50%;
+		text-align: center;
+	}
+
+	span {
+		padding-bottom: @post-padding;
+		color: rgba(127,127,127,.5);
+		font-size: 1em;
+		text-transform: uppercase;
+		line-height: 32px;
+	}
 }

--- a/less/modules/necro-post.less
+++ b/less/modules/necro-post.less
@@ -1,7 +1,10 @@
 .topic .necro-post {
 	text-align: center;
 	color: rgba(127,127,127,.5);
-	padding-bottom: @post-padding;
+
+	&:not(:last-child) {
+		padding-bottom: calc(@post-padding * 2);
+	}
 
 	.timeline-badge {
 		display: none;

--- a/less/modules/necro-post.less
+++ b/less/modules/necro-post.less
@@ -12,29 +12,3 @@
 		text-transform: uppercase;
 	}
 }
-
-@media (min-width: @screen-md-min) {
-	.topic .necro-post {
-		text-align: left;
-		font-size: 1em;
-
-		.timeline-badge {
-			float: left;
-			display: block;
-			width: 32px;
-			height: 32px;
-			line-height: 32px;
-			margin-left: -17px;
-			margin-right: 17px;
-			color: lighten(@brand-primary, 30%);
-			background-color: @body-bg;
-			border: 2px solid lighten(@brand-primary, 30%);
-			border-radius: 50%;
-			text-align: center;
-		}
-
-		span {
-			line-height: 32px;
-		}
-	}
-}

--- a/less/modules/necro-post.less
+++ b/less/modules/necro-post.less
@@ -1,6 +1,8 @@
 .topic .necro-post {
 	text-align: center;
 	color: rgba(127,127,127,.5);
+	margin-bottom: 0;
+	font-size: 1.5em;
 
 	&:not(:last-child) {
 		padding-bottom: calc(@post-padding * 2);
@@ -11,12 +13,14 @@
 	}
 
 	span {
-		font-size: 1.5em;
 		text-transform: uppercase;
 	}
+}
 
-	@media (min-width: @screen-md-min) {
+@media (min-width: @screen-md-min) {
+	.topic .necro-post {
 		text-align: left;
+		font-size: 1em;
 
 		.timeline-badge {
 			float: left;
@@ -34,7 +38,6 @@
 		}
 
 		span {
-			font-size: 1em;
 			line-height: 32px;
 		}
 	}

--- a/less/modules/necro-post.less
+++ b/less/modules/necro-post.less
@@ -1,14 +1,10 @@
 .topic .necro-post {
 	text-align: center;
-	color: rgba(127,127,127,.5);
 	margin-bottom: 0;
 	font-size: 1.5em;
+	border-left-style: dashed;
 
-	.timeline-badge {
-		display: none;
-	}
-
-	span {
-		text-transform: uppercase;
+	.timeline-text {
+		margin-left: 32px;
 	}
 }

--- a/less/modules/necro-post.less
+++ b/less/modules/necro-post.less
@@ -2,7 +2,6 @@
 	text-align: center;
 	margin-bottom: 0;
 	font-size: 1.5em;
-	border-left-style: dashed;
 
 	.timeline-text {
 		margin-left: 32px;

--- a/less/topic.less
+++ b/less/topic.less
@@ -426,6 +426,12 @@
 		list-style-type: none;
 		padding: 0;
 
+		@media (max-width: @screen-sm-max) {
+			[component="post"] {
+				margin-bottom: @post-padding;
+			}
+		}
+
 		[component="post"] {
 			position: relative;
 			.transition(0.75s ease-in-out border-color);

--- a/less/topic.less
+++ b/less/topic.less
@@ -411,6 +411,8 @@
 
 
 .topic {
+	.timeline;
+
 	&.deleted {
 		.opacity(0.3);
 
@@ -422,16 +424,9 @@
 	.posts {
 		list-style-type: none;
 		padding: 0;
-		[component="post"][data-index="0"] {
-			border-bottom: 5px solid @post-border-color;
-		}
+
 		[component="post"] {
 			position: relative;
-			border-bottom: 1px solid @post-border-color;
-
-			padding-bottom: @post-padding;
-			margin-bottom: @post-padding;
-
 			.transition(0.75s ease-in-out border-color);
 
 			.edit-icon {

--- a/less/topic.less
+++ b/less/topic.less
@@ -116,6 +116,7 @@
 				right: 12px;
 				font-size: 12px;
 				top: 0px;
+				z-index: 1;
 
 				@media (min-width: @screen-md-min) {
 					top: 2px;
@@ -652,12 +653,6 @@
 }
 
 [component="post"] {
-	&.topic-owner-post>.post-header .avatar {
-		-webkit-box-shadow: 0px 0px 4px 3px @brand-primary;
-		-moz-box-shadow: 0px 0px 4px 3px @brand-primary;
-		box-shadow: 0px 0px 4px 3px @brand-primary;
-	}
-
 	.avatar.avatar-sm2x {
 		font-size: 2.875rem;
 	}

--- a/less/topic.less
+++ b/less/topic.less
@@ -426,12 +426,6 @@
 		list-style-type: none;
 		padding: 0;
 
-		@media (max-width: @screen-sm-max) {
-			[component="post"] {
-				margin-bottom: @post-padding;
-			}
-		}
-
 		[component="post"] {
 			position: relative;
 			.transition(0.75s ease-in-out border-color);

--- a/less/variables.less
+++ b/less/variables.less
@@ -1,7 +1,7 @@
 //== Topic List
 //
-//## Post objects found on the category, recent, popular, etc. pages 
+//## Post objects found on the category, recent, popular, etc. pages
 
-@post-padding:			20px;
+@post-padding:			40px;
 @post-border-color: 	@gray-lighter;
 @post-highlight:		@brand-info;

--- a/less/variables.less
+++ b/less/variables.less
@@ -2,6 +2,6 @@
 //
 //## Post objects found on the category, recent, popular, etc. pages
 
-@post-padding:			40px;
+@post-padding:			20px;
 @post-border-color: 	@gray-lighter;
 @post-highlight:		@brand-info;

--- a/templates/partials/topic/event.tpl
+++ b/templates/partials/topic/event.tpl
@@ -2,5 +2,10 @@
 	<div class="timeline-badge">
 		<i class="fa {{{ if icon }}}{icon}{{{ else }}}fa-circle{{{ end }}}"></i>
 	</div>
-	<span class="timeline-text">{text}</span> <span class="timeago timeline-text" title="{timestampISO}"></span>
+	<span class="timeline-text">{text}&nbsp;</span>
+
+	{{{ if (user && !./user.system) }}}<span><a href="{config.relative_path}/user/{./user.userslug}">{buildAvatar(user, "xs", true)}&nbsp;{./user.username}</a></span>&nbsp;{{{ end }}}
+	{{{ if (user && ./user.system ) }}}<span class="timeline-text">[[global:system-user]]</span>&nbsp;{{{ end }}}
+
+	<span class="timeago timeline-text" title="{timestampISO}"></span>
 </li>

--- a/templates/partials/topic/event.tpl
+++ b/templates/partials/topic/event.tpl
@@ -1,0 +1,6 @@
+<li component="topic/event" class="timeline-event" data-topic-event-id="{id}">
+	<div class="timeline-badge">
+		<i class="fa {{{ if icon }}}{icon}{{{ else }}}fa-circle{{{ end }}}"></i>
+	</div>
+	<span class="timeline-text">{text}</span> <span class="timeago timeline-text" title="{timestampISO}"></span>
+</li>

--- a/templates/partials/topic/event.tpl
+++ b/templates/partials/topic/event.tpl
@@ -4,8 +4,12 @@
 	</div>
 	<span class="timeline-text">{text}&nbsp;</span>
 
-	{{{ if (user && !./user.system) }}}<span><a href="{config.relative_path}/user/{./user.userslug}">{buildAvatar(user, "xs", true)}&nbsp;{./user.username}</a></span>&nbsp;{{{ end }}}
-	{{{ if (user && ./user.system ) }}}<span class="timeline-text">[[global:system-user]]</span>&nbsp;{{{ end }}}
+	{{{ if user }}}
+		{{{ if !./user.system }}}<span><a href="{config.relative_path}/user/{./user.userslug}">{buildAvatar(user, "xs", true)}&nbsp;{./user.username}</a></span>&nbsp;{{{ end }}}
+		{{{ if ./user.system }}}<span class="timeline-text">[[global:system-user]]</span>&nbsp;{{{ end }}}
+	{{{ else }}}
+		<span class="timeline-text">[[global:unknown-user]]</span>&nbsp;
+	{{{ end }}}
 
 	<span class="timeago timeline-text" title="{timestampISO}"></span>
 </li>

--- a/templates/partials/topic/necro-post.tpl
+++ b/templates/partials/topic/necro-post.tpl
@@ -1,3 +1,6 @@
 <li component="topic/necro-post" class="necro-post">
+	<div class="timeline-badge">
+		<i class="fa fa-clock-o"></i>
+	</div>
 	<span>{text}</span>
 </li>

--- a/templates/partials/topic/necro-post.tpl
+++ b/templates/partials/topic/necro-post.tpl
@@ -1,6 +1,6 @@
 <li component="topic/necro-post" class="necro-post timeline-event">
 	<div class="timeline-badge">
-		<i class="fa fa-clock-o"></i>
+		<i class="fa fa-hourglass-half"></i>
 	</div>
 	<span class="timeline-text">{text}</span>
 </li>

--- a/templates/partials/topic/necro-post.tpl
+++ b/templates/partials/topic/necro-post.tpl
@@ -1,6 +1,6 @@
-<li component="topic/necro-post" class="necro-post">
+<li component="topic/necro-post" class="necro-post timeline-event">
 	<div class="timeline-badge">
 		<i class="fa fa-clock-o"></i>
 	</div>
-	<span>{text}</span>
+	<span class="timeline-text">{text}</span>
 </li>

--- a/templates/partials/topic/necro-post.tpl
+++ b/templates/partials/topic/necro-post.tpl
@@ -1,6 +1,3 @@
 <li component="topic/necro-post" class="necro-post timeline-event">
-	<div class="timeline-badge">
-		<i class="fa fa-hourglass-half"></i>
-	</div>
 	<span class="timeline-text">{text}</span>
 </li>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/923011/103312528-5d83e800-49eb-11eb-8cfe-dc28a3827a78.png)


I was hoping to take this base design and extend it in core to allow for "topic events", to allow plugins to add events to a topic when they happen.

e.g. Q&A plugin can add an event when the topic is marked solved (w/ link to solved pid)
e.g. Poll plugin can add an event when the poll closes

Note: In this particular implementation, I simply hacked the necro-post style to fit the timeline styling. Eventually, we'd want the necro-post labels to also be dynamically generated topic events.

Commits:
- feat: basic timeline-style styling for posts in a topic
- fix: mobile-style for timeline-style styling
