### PR TITLE
refactor: improve panel offset code

### DIFF
--- a/less/account.less
+++ b/less/account.less
@@ -32,7 +32,7 @@
 		margin-bottom: 1em;
 		background-origin: content-box;
 		width: 100%;
-		top: calc(var(--panel-offset) - 20px);
+		top: var(--panel-offset);
 		position: absolute;
 		left: auto;
 		right: 0px;

--- a/less/chats.less
+++ b/less/chats.less
@@ -37,6 +37,7 @@
 
 		.chat-search {
 			padding-bottom: 15px;
+			padding-top: 10px;
 			ul {
 				width: 100%;
 			}
@@ -566,9 +567,6 @@
 			display: none;
 		}
 
-		.chats-full, .chat-modal {
-			height: calc(100vh - var(--panel-offset));
-		}
 		[component="chat/messages"] {
 			width: calc(100vw);
 		}

--- a/less/groups.less
+++ b/less/groups.less
@@ -17,15 +17,16 @@
 	[component="groups/cover"] {
 		background-size: cover;
 		background-repeat: no-repeat;
-		min-height: 200px;
-		position: relative;
-		margin-bottom: 1em;
 		background-origin: content-box;
+
+		min-height: 200px;
 		width: 100%;
-		top: calc(var(--panel-offset) - 20px);
+		margin-bottom: 1em;
+
 		position: absolute;
+		top: var(--panel-offset);
+		right: 0;
 		left: auto;
-		right: 0px;
 
 		&:hover {
 			.controls {

--- a/less/header.less
+++ b/less/header.less
@@ -140,8 +140,11 @@
 	}
 }
 
-.header {
+.header.navbar-fixed-top {
+	position: sticky;
+}
 
+.header {
 	[component="navbar/title"] {
 		display: none !important; //temp
 	}

--- a/less/style.less
+++ b/less/style.less
@@ -7,10 +7,6 @@ body {
 	min-height: 100%;
 }
 
-#panel {
-	padding-top: var(--panel-offset);
-}
-
 @media (max-width: @screen-xs-max) {
 	.slideout-panel {
 		min-height: 100vh;
@@ -52,7 +48,7 @@ a:hover, .btn-link:hover, .btn-link:active, .btn-link:focus {
 }
 
 #content {
-	padding-bottom:20px;
+	padding-bottom: 20px;
 	-webkit-transition: opacity 150ms linear;
 	-moz-transition: opacity 150ms linear;
 	-ms-transition: opacity 150ms linear;

--- a/less/topic.less
+++ b/less/topic.less
@@ -41,7 +41,7 @@
 	}
 	.topic-header {
 		position: sticky;
-		top: calc(var(--panel-offset) - 20px);
+		top: var(--panel-offset);
 		background-color: @body-bg;
 		z-index: @zindex-navbar;
 		margin-left: -15px;

--- a/public/persona.js
+++ b/public/persona.js
@@ -7,30 +7,21 @@ $(document).ready(function () {
 	setupMobileMenu();
 	setupQuickReply();
 	configureNavbarHiding();
-	updatePanelOffset();
 
 	$(window).on('resize', utils.debounce(configureNavbarHiding, 200));
 	$(window).on('resize', updatePanelOffset);
 
 	function updatePanelOffset() {
-		const headerEl = document.getElementById('header-menu');
+		const header = document.getElementById('header-menu');
 
-		if (!headerEl) {
+		if (!header) {
 			console.warn('[persona/updatePanelOffset] Could not find #header-menu, panel offset unchanged.');
 			return;
 		}
 
-		const headerRect = headerEl.getBoundingClientRect();
-		const headerStyle = window.getComputedStyle(headerEl);
-
-		let offset =
-			headerRect.y + headerRect.height +
-			(parseInt(headerStyle.marginTop, 10) || 0) +
-			(parseInt(headerStyle.marginBottom, 10) || 0);
-
-		offset = Math.max(0, offset);
+		const rect = header.getBoundingClientRect();
+		const offset = Math.max(0, rect.bottom);
 		document.documentElement.style.setProperty('--panel-offset', `${offset}px`);
-		localStorage.setItem('panelOffset', offset);
 	}
 
 	var lastBSEnv = '';

--- a/templates/header.tpl
+++ b/templates/header.tpl
@@ -11,7 +11,6 @@
 		var app = {
 			user: JSON.parse('{{userJSON}}')
 		};
-		document.documentElement.style.setProperty('--panel-offset', `${localStorage.getItem('panelOffset') || 0}px`);
 	</script>
 
 	{{{if useCustomHTML}}}
@@ -36,6 +35,11 @@
 				<!-- IMPORT partials/menu.tpl -->
 			</div>
 		</nav>
+		<script>
+			const rect = document.getElementById('header-menu').getBoundingClientRect();
+			const offset = Math.max(0, rect.bottom);
+			document.documentElement.style.setProperty('--panel-offset', offset + `px`);
+		</script>
 		<div class="container" id="content">
 		<!-- IMPORT partials/noscript/warning.tpl -->
 		<!-- IMPORT partials/noscript/message.tpl -->


### PR DESCRIPTION
- Use sticky instead for navbar
- Keep var around for topic header and such
- But move the code so it gets set immediately as page loads
- Changed offset to just bottom of header (not including margin) so less `calc( .. - 20px)` is needed