### PR TITLE
refactor: improve panel offset code

### DIFF
--- a/public/persona.js
+++ b/public/persona.js
@@ -7,30 +7,21 @@ $(document).ready(function () {
 	setupMobileMenu();
 	setupQuickReply();
 	configureNavbarHiding();
-	updatePanelOffset();
 
 	$(window).on('resize', utils.debounce(configureNavbarHiding, 200));
 	$(window).on('resize', updatePanelOffset);
 
 	function updatePanelOffset() {
-		const headerEl = document.getElementById('header-menu');
+		const header = document.getElementById('header-menu');
 
-		if (!headerEl) {
+		if (!header) {
 			console.warn('[persona/updatePanelOffset] Could not find #header-menu, panel offset unchanged.');
 			return;
 		}
 
-		const headerRect = headerEl.getBoundingClientRect();
-		const headerStyle = window.getComputedStyle(headerEl);
-
-		let offset =
-			headerRect.y + headerRect.height +
-			(parseInt(headerStyle.marginTop, 10) || 0) +
-			(parseInt(headerStyle.marginBottom, 10) || 0);
-
-		offset = Math.max(0, offset);
+		const rect = header.getBoundingClientRect();
+		const offset = Math.max(0, rect.bottom);
 		document.documentElement.style.setProperty('--panel-offset', `${offset}px`);
-		localStorage.setItem('panelOffset', offset);
 	}
 
 	var lastBSEnv = '';

--- a/scss/chats.scss
+++ b/scss/chats.scss
@@ -80,9 +80,6 @@
 	[component="chat/main-wrapper"] {
 		flex: 3;
 		padding-bottom: 15px;
-		.alert {
-			margin: 1em;
-		}
 	}
 
 	[component="chat/messages"] {
@@ -553,9 +550,6 @@
 			display: none;
 		}
 
-		.chats-full, .chat-modal {
-			height: calc(100vh - var(--panel-offset));
-		}
 		[component="chat/messages"] {
 			width: calc(100vw);
 		}

--- a/scss/groups.scss
+++ b/scss/groups.scss
@@ -17,15 +17,18 @@
 	[component="groups/cover"] {
 		background-size: cover;
 		background-repeat: no-repeat;
-		min-height: 200px;
-		position: relative;
-		margin-bottom: 1em;
 		background-origin: content-box;
+
+		min-height: 200px;
 		width: 100%;
-		top: var(--panel-offset);
+		margin-bottom: 1em;
+		padding-left: 0;
+		padding-right: 0;
+
 		position: absolute;
+		top: var(--panel-offset);
+		right: 0;
 		left: auto;
-		right: 0px;
 
 		&:hover {
 			.controls {

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -7,10 +7,6 @@ body {
 	min-height: 100%;
 }
 
-#panel {
-	padding-top: var(--panel-offset);
-}
-
 @include media-breakpoint-down(sm) {
 	.slideout-panel {
  		min-height: 100vh;
@@ -48,7 +44,7 @@ a:hover, .btn-link:hover, .btn-link:active, .btn-link:focus {
 }
 
 #content {
-	padding-bottom:20px;
+	padding-bottom: 20px;
 	-webkit-transition: opacity 150ms linear;
 	-moz-transition: opacity 150ms linear;
 	-ms-transition: opacity 150ms linear;

--- a/scss/topic.scss
+++ b/scss/topic.scss
@@ -41,7 +41,7 @@
 	}
 	.topic-header {
 		position: sticky;
-		top: calc(var(--panel-offset));
+		top: var(--panel-offset);
 		background-color: $body-bg;
 		z-index: $zindex-sticky;
 	}

--- a/scss/topic.scss
+++ b/scss/topic.scss
@@ -40,10 +40,9 @@
 		margin-bottom: -5px;
 	}
 	.topic-header {
-		position: sticky;
 		top: var(--panel-offset);
 		background-color: $body-bg;
-		z-index: $zindex-sticky;
+		z-index: $zindex-dropdown;
 	}
 
 	.topic-info {

--- a/templates/header.tpl
+++ b/templates/header.tpl
@@ -32,11 +32,16 @@
 	</nav>
 
 	<main id="panel" class="slideout-panel">
-		<nav class="navbar fixed-top navbar-expand-lg bg-light header border-bottom" id="header-menu" component="navbar">
+		<nav class="navbar sticky-top navbar-expand-lg bg-light header border-bottom" id="header-menu" component="navbar">
 			<div class="container justify-content-start">
 				<!-- IMPORT partials/menu.tpl -->
 			</div>
 		</nav>
+		<script>
+			const rect = document.getElementById('header-menu').getBoundingClientRect();
+			const offset = Math.max(0, rect.bottom);
+			document.documentElement.style.setProperty('--panel-offset', offset + `px`);
+		</script>
 		<div class="container pt-3" id="content">
 		<!-- IMPORT partials/noscript/warning.tpl -->
 		<!-- IMPORT partials/noscript/message.tpl -->

--- a/templates/partials/chats/message-window.tpl
+++ b/templates/partials/chats/message-window.tpl
@@ -26,7 +26,7 @@
 	</div>
 </div>
 <!-- ELSE -->
-<div class="alert alert-info">
+<div class="alert alert-info me-3">
 	[[modules:chat.no-messages]]
 </div>
 <!-- ENDIF roomId -->

--- a/templates/topic.tpl
+++ b/templates/topic.tpl
@@ -5,7 +5,7 @@
 </div>
 <div class="row">
 	<div class="topic <!-- IF widgets.sidebar.length -->col-lg-9 col-sm-12<!-- ELSE -->col-lg-12<!-- ENDIF widgets.sidebar.length -->">
-		<div class="topic-header">
+		<div class="topic-header sticky-top">
 			<h1 component="post/header" class="" itemprop="name">
 				<span class="topic-title">
 					<span component="topic/labels">


### PR DESCRIPTION
@pitaj said:

* Use sticky instead for navbar
* Keep var around for topic header and such
* But move the code so it gets set immediately as page loads
* Changed offset to just bottom of header (not including margin) so less `calc( .. - 20px)` is needed

