### PR TITLE
Use fa-chevron-circle-up (and down) for upvoted and downvoted

### DIFF
--- a/less/topic.less
+++ b/less/topic.less
@@ -163,14 +163,14 @@
 		}
 	}
 
-	[component="post/upvote"].upvoted {
-		border-radius: 3px;
-		border: 1px solid @brand-success;
+	[component="post/upvote"].upvoted i::before {
+		content: @fa-var-chevron-circle-up;
+		color: @brand-primary;
 	}
 
-	[component="post/downvote"].downvoted {
-		border-radius: 3px;
-		border: 1px solid @brand-warning;
+	[component="post/downvote"].downvoted i::before {
+		content: @fa-var-chevron-circle-down;
+		color: @brand-primary;
 	}
 
 	[component="post/vote-count"] {


### PR DESCRIPTION
- chore: v12.1.7
- docs: update readme re: v2.x and v3.x usage
- fix: #10981, use fa-chevron-circle-up (and down) on upvoted and downvoted
