### PR TITLE
Fix typo in notifications.tpl

### DIFF
--- a/templates/partials/header/notifications.tpl
+++ b/templates/partials/header/notifications.tpl
@@ -1,4 +1,4 @@
-<a data-bs-toggle="dropdown" data-bs-autoclose="outside" href="#" role="button" class="nav-link position-relative" aria-haspopup="true" aria-expanded="false" aria-label="[[global:header.notifications]]">
+<a data-bs-toggle="dropdown" data-bs-auto-close="outside" href="#" role="button" class="nav-link position-relative" aria-haspopup="true" aria-expanded="false" aria-label="[[global:header.notifications]]">
 	<i component="notifications/icon" class="fa fa-fw {{{ if unreadCount.notification}}}fa-bell{{{ else }}}fa-bell-o{{{ end }}} unread-count" data-content="{unreadCount.notification}"></i>
 </a>
 


### PR DESCRIPTION
The misspelled `data-bs-autoclose` is causing the dropdown to close on any click inside. (unread button etc)